### PR TITLE
chore: prepare changelog for public consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 <!-- This CHANGELOG is populated automatically by commitizen, but can be manually edited if needed. -->
 
+# `qnexus` Changelog
+
 ## 0.6.0 (2024-09-19)
 
 
@@ -78,20 +80,12 @@
 
 ### Feat
 
-- save refs to filesystem (#61)
-- project summarize (#60)
-- add utility methods for compiling, executing and creating/getting projects (#45)
-- explicit type signatures for docstrings (#49)
+- Save refs to filesystem (#61)
+- Project summarize (#60)
+- Add utility methods for compiling, executing and creating/getting projects (#45)
+- Explicit type signatures for docstrings (#49)
 - Use jupyterhub token format and allow configurable token path via env. (#30)
 - Add h series noise model (#33)
 - Restore some cli functionality (#28)
 - Allow querying by properties (#22)
 - Allow job properties to be passed (#21)
-
-### Fixed
-
-- update small tests (#20)
-
-### Refactor
-
-- use v1beta jobs API and refactor models (#42)


### PR DESCRIPTION
Minor cleanup. Idea is to then symlink it and publish it as part of the nexus docs.