### PR TITLE
infra: integration test workflow to enable external contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Python package CI
 
 on:
   pull_request:
@@ -7,17 +7,7 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      run_integration_tests_only:
-        type: boolean
-        description: "Run integration tests only?"
-        required: false
-        default: false
-  schedule:
-    # everyday at 12:00
-    - cron: '0 12 * * *'
-
+      
 jobs:
 
   version-matrix-integration:
@@ -48,7 +38,6 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    if: (!inputs.run_integration_tests_only || github.event_name != 'schedule')
     strategy:
       matrix:
         python-version: ['3.11']
@@ -101,7 +90,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    if: (!inputs.run_integration_tests_only || github.event_name != 'schedule')
     strategy:
       matrix:
         python-version: ['3.10', '3.11']
@@ -141,60 +129,3 @@ jobs:
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: htmlcov/
-
-
-  test-integration:
-    name: Integration
-    needs: [version-matrix-integration]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.11']
-    env:
-      NEXUS_QA_USER_EMAIL: ${{ secrets.NEXUS_QA_USER_EMAIL }}
-      NEXUS_QA_USER_PASSWORD: ${{ secrets.NEXUS_QA_USER_PASSWORD }}
-      NEXUS_DOMAIN: "qa.myqos.com"
-      NEXUS_STORE_TOKENS: "false"
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
-   
-      - name: Cache poetry
-        uses: actions/cache@v3.3.1
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Setup poetry
-        run: |
-          pip install pip==22.2.1 poetry==1.6.1
-          poetry run pip install --upgrade pip
-
-      - name: Install dev dependencies
-        run: |
-          poetry install --all-extras
-      
-      - name: Set up qnexus login tokens
-        run: |
-          poetry run python integration/setup_tokens.py
-
-      - name: Run integration tests
-        run: |
-          poetry run pytest integration/ --html=integration-results.html --timeout=600 -ra --reruns 3
-
-      - name: Upload integration test results
-        uses: actions/upload-artifact@master
-        with:
-          path: |
-            ./integration-results-*.html
-            ./assets/*.css
-          name: integration-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,33 +7,8 @@ on:
   push:
     branches:
       - main
-      
+
 jobs:
-
-  version-matrix-integration:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11']
-    steps:
-      - uses: actions/checkout@v3
-      - name: Cache poetry
-        uses: actions/cache@v3.3.1
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
-      - name: Set up ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Setup poetry
-        run: |
-          pip install pip==22.2.1 poetry==1.8.2
-          poetry run pip install --upgrade pip
-      - name: Install dev dependencies
-        run: |
-          poetry install --all-extras
-
 
   check:
     name: Check

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,96 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number (for external PRs)'
+        required: false
+        type: number
+  schedule:
+    # everyday at 12:00
+    - cron: '0 12 * * *'
+
+jobs:
+
+  version-matrix-integration:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache poetry
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
+      - name: Set up ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup poetry
+        run: |
+          pip install pip==22.2.1 poetry==1.8.2
+          poetry run pip install --upgrade pip
+      - name: Install dev dependencies
+        run: |
+          poetry install --all-extras
+
+  test-integration:
+    name: Integration
+    needs: [version-matrix-integration]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11']
+    env:
+      NEXUS_QA_USER_EMAIL: ${{ secrets.NEXUS_QA_USER_EMAIL }}
+      NEXUS_QA_USER_PASSWORD: ${{ secrets.NEXUS_QA_USER_PASSWORD }}
+      NEXUS_DOMAIN: "qa.myqos.com"
+      NEXUS_STORE_TOKENS: "false"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+          # Use the pull request merge commit ref if one is provided
+          ref: ${{ github.event.inputs.pr_number && format('refs/pull/{0}/merge', github.event.inputs.pr_number) || 'main' }}
+   
+      - name: Cache poetry
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup poetry
+        run: |
+          pip install pip==22.2.1 poetry==1.6.1
+          poetry run pip install --upgrade pip
+
+      - name: Install dev dependencies
+        run: |
+          poetry install --all-extras
+      
+      - name: Set up qnexus login tokens
+        run: |
+          poetry run python integration/setup_tokens.py
+
+      - name: Run integration tests
+        run: |
+          poetry run pytest integration/ --html=integration-results.html --timeout=600 -ra --reruns 3
+
+      - name: Upload integration test results
+        uses: actions/upload-artifact@master
+        with:
+          path: |
+            ./integration-results-*.html
+            ./assets/*.css
+          name: integration-results

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ And can be run with:
 poetry run pytest integration/
 ```
 
+These will only be available to internal team members. For external contributions we recommend writing unit tests and/or integration tests and requesting they
+be run by an internal reviewer.
+
 Run basic unit tests using
 
 ```sh


### PR DESCRIPTION
Basically external contributors will always be unable to run the integration tests as these require github secret authentication credentials. New proposed workflow:

1. PRs trigger basic workflow (checks and unit tests)
2. Reviewers trigger the integration test workflow on a given branch by providing the PR number in a workflow dispatch.
3. This integration test workflow is also run on a schedule.