### PR TITLE
feat: Allow use of scope for single resources

### DIFF
--- a/qnexus/client/circuits.py
+++ b/qnexus/client/circuits.py
@@ -136,7 +136,7 @@ def get(
     not match exactly one object.
     """
     if id:
-        return _fetch_by_id(circuit_id=id)
+        return _fetch_by_id(circuit_id=id, scope=scope)
 
     return get_all(
         name_like=name_like,
@@ -244,10 +244,13 @@ def update(
     )
 
 
-def _fetch_by_id(circuit_id: UUID | str) -> CircuitRef:
+def _fetch_by_id(circuit_id: UUID | str, scope: ScopeFilterEnum | None) -> CircuitRef:
     """Utility method for fetching directly by a unique identifier."""
+    params = Params(
+        scope=scope,
+    ).model_dump(by_alias=True, exclude_unset=True, exclude_none=True)
 
-    res = get_nexus_client().get(f"/api/circuits/v1beta/{circuit_id}")
+    res = get_nexus_client().get(f"/api/circuits/v1beta/{circuit_id}", params=params)
 
     handle_fetch_errors(res)
 

--- a/qnexus/client/jobs/__init__.py
+++ b/qnexus/client/jobs/__init__.py
@@ -360,11 +360,13 @@ async def listen_job_status(
 
 
 @overload
-def results(job: CompileJobRef) -> DataframableList[CompilationResultRef]: ...
+def results(job: CompileJobRef) -> DataframableList[CompilationResultRef]:
+    ...
 
 
 @overload
-def results(job: ExecuteJobRef) -> DataframableList[ExecutionResultRef]: ...
+def results(job: ExecuteJobRef) -> DataframableList[ExecutionResultRef]:
+    ...
 
 
 def results(

--- a/qnexus/client/jobs/__init__.py
+++ b/qnexus/client/jobs/__init__.py
@@ -211,7 +211,7 @@ def get(  # pylint: disable=too-many-positional-arguments
     not match exactly one object.
     """
     if id:
-        return _fetch_by_id(job_id=id)
+        return _fetch_by_id(job_id=id, scope=scope)
 
     return get_all(
         name_like=name_like,
@@ -231,9 +231,13 @@ def get(  # pylint: disable=too-many-positional-arguments
     ).try_unique_match()
 
 
-def _fetch_by_id(job_id: UUID | str) -> JobRef:
+def _fetch_by_id(job_id: UUID | str, scope: ScopeFilterEnum | None) -> JobRef:
     """Utility method for fetching directly by a unique identifier."""
-    res = get_nexus_client().get(f"/api/jobs/v1beta/{job_id}")
+    params = Params(
+        scope=scope,
+    ).model_dump(by_alias=True, exclude_unset=True, exclude_none=True)
+
+    res = get_nexus_client().get(f"/api/jobs/v1beta/{job_id}", params=params)
 
     handle_fetch_errors(res)
 
@@ -356,13 +360,11 @@ async def listen_job_status(
 
 
 @overload
-def results(job: CompileJobRef) -> DataframableList[CompilationResultRef]:
-    ...
+def results(job: CompileJobRef) -> DataframableList[CompilationResultRef]: ...
 
 
 @overload
-def results(job: ExecuteJobRef) -> DataframableList[ExecutionResultRef]:
-    ...
+def results(job: ExecuteJobRef) -> DataframableList[ExecutionResultRef]: ...
 
 
 def results(

--- a/qnexus/client/jobs/_compile.py
+++ b/qnexus/client/jobs/_compile.py
@@ -245,18 +245,16 @@ def _fetch_compilation_passes(
         pass_input_circuit_id = pass_info["relationships"]["original_circuit"]["data"][
             "id"
         ]
-        pass_input_circuit = (
-            circuit_api._fetch_by_id(  # pylint: disable=protected-access
-                pass_input_circuit_id
-            )
+        pass_input_circuit = circuit_api._fetch_by_id(  # pylint: disable=protected-access
+            pass_input_circuit_id,
+            scope=None,
         )
         pass_output_circuit_id = pass_info["relationships"]["compiled_circuit"]["data"][
             "id"
         ]
-        pass_output_circuit = (
-            circuit_api._fetch_by_id(  # pylint: disable=protected-access
-                pass_output_circuit_id
-            )
+        pass_output_circuit = circuit_api._fetch_by_id(  # pylint: disable=protected-access
+            pass_output_circuit_id,
+            scope=None,
         )
 
         pass_list.append(

--- a/qnexus/client/jobs/_compile.py
+++ b/qnexus/client/jobs/_compile.py
@@ -245,16 +245,20 @@ def _fetch_compilation_passes(
         pass_input_circuit_id = pass_info["relationships"]["original_circuit"]["data"][
             "id"
         ]
-        pass_input_circuit = circuit_api._fetch_by_id(  # pylint: disable=protected-access
-            pass_input_circuit_id,
-            scope=None,
+        pass_input_circuit = (
+            circuit_api._fetch_by_id(  # pylint: disable=protected-access
+                pass_input_circuit_id,
+                scope=None,
+            )
         )
         pass_output_circuit_id = pass_info["relationships"]["compiled_circuit"]["data"][
             "id"
         ]
-        pass_output_circuit = circuit_api._fetch_by_id(  # pylint: disable=protected-access
-            pass_output_circuit_id,
-            scope=None,
+        pass_output_circuit = (
+            circuit_api._fetch_by_id(  # pylint: disable=protected-access
+                pass_output_circuit_id,
+                scope=None,
+            )
         )
 
         pass_list.append(

--- a/qnexus/client/jobs/_execute.py
+++ b/qnexus/client/jobs/_execute.py
@@ -167,7 +167,8 @@ def _fetch_execution_result(
     input_circuit_id = res_dict["data"]["relationships"]["circuit"]["data"]["id"]
 
     input_circuit = circuit_api._fetch_by_id(  # pylint: disable=protected-access
-        input_circuit_id, scope=None,
+        input_circuit_id,
+        scope=None,
     )
 
     results_data = res_dict["data"]["attributes"]

--- a/qnexus/client/jobs/_execute.py
+++ b/qnexus/client/jobs/_execute.py
@@ -167,7 +167,7 @@ def _fetch_execution_result(
     input_circuit_id = res_dict["data"]["relationships"]["circuit"]["data"]["id"]
 
     input_circuit = circuit_api._fetch_by_id(  # pylint: disable=protected-access
-        input_circuit_id
+        input_circuit_id, scope=None,
     )
 
     results_data = res_dict["data"]["attributes"]

--- a/qnexus/client/projects.py
+++ b/qnexus/client/projects.py
@@ -120,7 +120,7 @@ def get(
     not match exactly one object.
     """
     if id:
-        return _fetch_by_id(id)
+        return _fetch_by_id(id, scope=scope)
 
     return get_all(
         name_like=name_like,
@@ -159,9 +159,13 @@ def get_or_create(
         )
 
 
-def _fetch_by_id(project_id: UUID | str) -> ProjectRef:
+def _fetch_by_id(project_id: UUID | str, scope: ScopeFilterEnum | None) -> ProjectRef:
     """Utility method for fetching directly by a unique identifier."""
-    res = get_nexus_client().get(f"/api/projects/v1beta/{project_id}")
+    params = Params(scope=scope).model_dump(
+        by_alias=True, exclude_unset=True, exclude_none=True
+    )
+
+    res = get_nexus_client().get(f"/api/projects/v1beta/{project_id}", params=params)
 
     handle_fetch_errors(res)
 

--- a/qnexus/client/wasm_modules.py
+++ b/qnexus/client/wasm_modules.py
@@ -134,7 +134,7 @@ def get(
     not match exactly one object.
     """
     if id:
-        return _fetch_by_id(wasm_module_id=id)
+        return _fetch_by_id(wasm_module_id=id, scope=scope)
 
     return get_all(
         name_like=name_like,
@@ -241,10 +241,15 @@ def update(
     )
 
 
-def _fetch_by_id(wasm_module_id: UUID | str) -> WasmModuleRef:
+def _fetch_by_id(
+    wasm_module_id: UUID | str, scope: ScopeFilterEnum | None
+) -> WasmModuleRef:
     """Utility method for fetching directly by a unique identifier."""
+    params = Params(
+        scope=scope,
+    ).model_dump(by_alias=True, exclude_unset=True, exclude_none=True)
 
-    res = get_nexus_client().get(f"/api/wasm/v1beta/{wasm_module_id}")
+    res = get_nexus_client().get(f"/api/wasm/v1beta/{wasm_module_id}", params=params)
 
     handle_fetch_errors(res)
 


### PR DESCRIPTION
When filtering by scope, if you specify a resource id the scope was not being passed to the internal _get_by_id functions. This commit changes that to allow scope to be passed when a single id is specified.