### PR TITLE
ci: post useful integration test messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,10 @@ jobs:
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: htmlcov/
+
+      - name: Comment with integration test review reminder
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            Hello and thank you for making a PR to qnexus! :wave:
+            A maintainer will review and run integration tests if required.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,3 @@ jobs:
           name: pytest-results-${{ matrix.python-version }}
           path: htmlcov/
 
-      - name: Comment with integration test review reminder
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          message: |
-            Hello and thank you for making a PR to qnexus! :wave:
-            A maintainer will review and run integration tests if required.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,6 +52,14 @@ jobs:
       NEXUS_STORE_TOKENS: "false"
 
     steps:
+      - name: Comment action run link on PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            Integration tests are running on this PR at:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+          pr-number: ${{ github.event.inputs.pr_number }}
+
       - name: Checkout code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -21,3 +21,13 @@ jobs:
         uses: CQCL/hugrverse-actions/.github/workflows/pr-title.yml@main
         secrets:
             GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    comment-on-pr:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Comment on Pull Request
+          uses: thollander/actions-comment-pull-request@v3
+          with:
+            message: |
+              Hello and thank you for making a PR to qnexus! :wave:
+              A maintainer will review and run integration tests if required.


### PR DESCRIPTION
Adds a message to each PR with a reminder to reviewers to run the integration tests manually if required.

Also comments on each PR with a link to the integration test run (if/when it is run).