### PR TITLE
feat: fetch incomplete job results

### DIFF
--- a/examples/basics/jobs_results.ipynb
+++ b/examples/basics/jobs_results.ipynb
@@ -208,6 +208,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Getting results for unfinished or incomplete jobs\n",
+    "\n",
+    "By default, you can only retrieve results for jobs with the COMPLETED status (meaning that all items in the Job have successfully completed). \n",
+    "\n",
+    "In some contexts you may want to retrieve results for the completed items in an otherwise pending or errored job. For example, maybe you have submitted 10 circuits to be executed on quantum hardware, but only 6 of them have completed before you ran out of credit quota for that device. In this case you can still get the results from the completed items."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fetch the completed results for an otherwise incomplete job\n",
+    "execute_job_result_refs = qnx.jobs.results(\n",
+    "    job=execute_job_ref,\n",
+    "    allow_incomplete=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Managing Jobs\n",
     "\n",
     "You can use the API to check on jobs, but also perform operations like cancelling or retrying."

--- a/qnexus/client/jobs/__init__.py
+++ b/qnexus/client/jobs/__init__.py
@@ -360,24 +360,35 @@ async def listen_job_status(
 
 
 @overload
-def results(job: CompileJobRef) -> DataframableList[CompilationResultRef]:
+def results(
+    job: CompileJobRef, allow_incomplete: bool = False
+) -> DataframableList[CompilationResultRef]:
     ...
 
 
 @overload
-def results(job: ExecuteJobRef) -> DataframableList[ExecutionResultRef]:
+def results(
+    job: ExecuteJobRef, allow_incomplete: bool = False
+) -> DataframableList[ExecutionResultRef]:
     ...
 
 
 def results(
     job: CompileJobRef | ExecuteJobRef,
+    allow_incomplete: bool = False,
 ) -> DataframableList[CompilationResultRef] | DataframableList[ExecutionResultRef]:
-    """Get the ResultRefs from a JobRef, if the job is complete."""
+    """Get the ResultRefs from a JobRef, if the job is complete.
+    To enable fetching results from Jobs with incomplete items, set allow_incomplete=True.
+    """
     match job:
         case CompileJobRef():
-            return _compile._results(job)  # pylint: disable=protected-access
+            return _compile._results(  # pylint: disable=protected-access
+                job, allow_incomplete
+            )
         case ExecuteJobRef():
-            return _execute._results(job)  # pylint: disable=protected-access
+            return _execute._results(  # pylint: disable=protected-access
+                job, allow_incomplete
+            )
         case _:
             assert_never(job.job_type)
 

--- a/qnexus/client/jobs/_compile.py
+++ b/qnexus/client/jobs/_compile.py
@@ -128,7 +128,7 @@ def _results(
     compilation_ids = [
         item["compilation_id"]
         for item in resp_data["attributes"]["definition"]["items"]
-        if item["status"] == "COMPLETED"
+        if item["status"]["status"] == "COMPLETED"
     ]
 
     compilation_refs: DataframableList[CompilationResultRef] = DataframableList([])

--- a/qnexus/client/jobs/_compile.py
+++ b/qnexus/client/jobs/_compile.py
@@ -108,6 +108,7 @@ def start_compile_job(  # pylint: disable=too-many-arguments, too-many-locals, t
 
 def _results(
     compile_job: CompileJobRef,
+    allow_incomplete: bool = False,
 ) -> DataframableList[CompilationResultRef]:
     """Get the results from a compile job."""
 
@@ -121,13 +122,13 @@ def _results(
 
     job_status = resp_data["attributes"]["status"]["status"]
 
-    if job_status != "COMPLETED":
-        # TODO maybe we want to return a partial list of results?
+    if job_status != "COMPLETED" and not allow_incomplete:
         raise qnx_exc.ResourceFetchFailed(message=f"Job status: {job_status}")
 
     compilation_ids = [
         item["compilation_id"]
         for item in resp_data["attributes"]["definition"]["items"]
+        if item["status"] == "COMPLETED"
     ]
 
     compilation_refs: DataframableList[CompilationResultRef] = DataframableList([])

--- a/qnexus/client/jobs/_execute.py
+++ b/qnexus/client/jobs/_execute.py
@@ -124,6 +124,7 @@ def start_execute_job(  # pylint: disable=too-many-arguments, too-many-locals, t
 
 def _results(
     execute_job: ExecuteJobRef,
+    allow_incomplete: bool = False,
 ) -> DataframableList[ExecutionResultRef]:
     """Get the results from an execute job."""
 
@@ -136,20 +137,20 @@ def _results(
     resp_data = resp.json()["data"]
     job_status = resp_data["attributes"]["status"]["status"]
 
-    if job_status != "COMPLETED":
-        # TODO maybe we want to return a partial list of results?
+    if job_status != "COMPLETED" and not allow_incomplete:
         raise qnx_exc.ResourceFetchFailed(message=f"Job status: {job_status}")
 
     execute_results: DataframableList[ExecutionResultRef] = DataframableList([])
 
     for item in resp_data["attributes"]["definition"]["items"]:
-        result_ref = ExecutionResultRef(
-            id=item["result_id"],
-            annotations=execute_job.annotations,
-            project=execute_job.project,
-        )
+        if item["status"] == "COMPLETED":
+            result_ref = ExecutionResultRef(
+                id=item["result_id"],
+                annotations=execute_job.annotations,
+                project=execute_job.project,
+            )
 
-        execute_results.append(result_ref)
+            execute_results.append(result_ref)
 
     return execute_results
 

--- a/qnexus/client/jobs/_execute.py
+++ b/qnexus/client/jobs/_execute.py
@@ -143,7 +143,7 @@ def _results(
     execute_results: DataframableList[ExecutionResultRef] = DataframableList([])
 
     for item in resp_data["attributes"]["definition"]["items"]:
-        if item["status"] == "COMPLETED":
+        if item["status"]["status"] == "COMPLETED":
             result_ref = ExecutionResultRef(
                 id=item["result_id"],
                 annotations=execute_job.annotations,


### PR DESCRIPTION
- [ ] User can request results for an 'incomplete' job (the term 'partial results' is already used for Quantinuum Systems so opted to not overload it)
- [ ] Basic documentation example
- [ ] Integration tests 