### PR TITLE
ci: restrict reviewers and only show welcome message when PR is opened

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # for syntax see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-# base rule, Nexus (fka mushroom) team is codeowner for whole repo
-* @CQCL/mushroom
+# Nexus team members for qnexus
+* @CQCL/qnexus

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,6 +24,7 @@ jobs:
 
     comment-on-pr:
       runs-on: ubuntu-latest
+      if: ${{ github.event.action == 'opened' }}
       steps:
         - name: Comment on Pull Request
           uses: thollander/actions-comment-pull-request@v3


### PR DESCRIPTION
- [x] Only show welcome message when PR is opened
- [x] Only auto-assign reviewers from a subset of the Nexus team
