### PR TITLE
chore: Pin github runner versions to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.11']
@@ -64,7 +64,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.10', '3.11']

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ on:
 jobs:
 
   version-matrix-integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.10', '3.11']
@@ -40,7 +40,7 @@ jobs:
   test-integration:
     name: Integration
     needs: [version-matrix-integration]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -23,7 +23,7 @@ jobs:
             GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     comment-on-pr:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-24.04
       steps:
         - name: Comment on Pull Request
           uses: thollander/actions-comment-pull-request@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   
 jobs:
   build-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
This way we're clearer what version we're running on (which has been Ubuntu 24.04 since January 17 2025).