### PR TITLE
chore: update hello message to avoid repetition

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -31,4 +31,4 @@ jobs:
             comment_tag: hello
             message: |
               Hello and thank you for making a PR to qnexus! :wave:
-              Update for test
+              A maintainer will review and run integration tests if required.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -31,4 +31,4 @@ jobs:
             comment_tag: hello
             message: |
               Hello and thank you for making a PR to qnexus! :wave:
-              A maintainer will review and run integration tests if required.
+              Update for test

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,7 +28,7 @@ jobs:
         - name: Comment on Pull Request
           uses: thollander/actions-comment-pull-request@v3
           with:
+            comment_tag: hello
             message: |
               Hello and thank you for making a PR to qnexus! :wave:
               A maintainer will review and run integration tests if required.
-            comment-tag: hello

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -31,3 +31,4 @@ jobs:
             message: |
               Hello and thank you for making a PR to qnexus! :wave:
               A maintainer will review and run integration tests if required.
+            comment-tag: hello

--- a/README.md
+++ b/README.md
@@ -135,6 +135,3 @@ This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http:
 
 
 Copyright 2025 Quantinuum Ltd.
-
-
-<!-- Test change. REMOVE!>

--- a/README.md
+++ b/README.md
@@ -135,3 +135,6 @@ This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http:
 
 
 Copyright 2025 Quantinuum Ltd.
+
+
+<!-- Test change. REMOVE!>


### PR DESCRIPTION
According to the github action documentation the `commit_tag` will ensure to update the same comment. See https://github.com/thollander/actions-comment-pull-request/tree/v3/?tab=readme-ov-file#update-a-comment

Unfortunately, I can't test it without merging it first.