### PR TITLE
chore: correct comment_tag to comment-tag in PR workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,7 +28,7 @@ jobs:
         - name: Comment on Pull Request
           uses: thollander/actions-comment-pull-request@v3
           with:
-            comment_tag: hello
+            comment-tag: hello
             message: |
               Hello and thank you for making a PR to qnexus! :wave:
               A maintainer will review and run integration tests if required.


### PR DESCRIPTION
There is a typo in the action README. It should be `comment-tag` not `comment_tag`