### PR TITLE
chore: fix integration test workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,9 +46,6 @@ jobs:
           # Use the pull request merge commit ref if one is provided
           ref: ${{ github.event.inputs.pr_number && format('refs/pull/{0}/merge', github.event.inputs.pr_number) || 'main' }}
 
-      - name: Set up Python
-        run: uv python install 3.12
-
       - name: Set up uv & venv
         uses: astral-sh/setup-uv@v5
         with:


### PR DESCRIPTION
The `astral-sh/setup-uv@v5` action will setup python for the worker so these lines can be deleted.