### PR TITLE
fix: login and reload tokens without restarting environment

### DIFF
--- a/qnexus/client/__init__.py
+++ b/qnexus/client/__init__.py
@@ -23,6 +23,7 @@ class AuthHandler(httpx.Auth):
             token = read_token(
                 "refresh_token",
             )
+            print(f"Token: {token}")
             self.cookies.set("myqos_oat", token, domain=get_config().domain)
         except FileNotFoundError:
             pass  # Okay to ignore this as the user may log in later
@@ -43,13 +44,13 @@ class AuthHandler(httpx.Auth):
                     self.cookies.set("myqos_oat", token, domain=get_config().domain)
                 except FileNotFoundError as exc:
                     raise AuthenticationError(
-                        "Not authenticated. Please run `qnx login` in your terminal."
+                        "Not authenticated. Please run qnx.login()."
                     ) from exc
 
             auth_response = yield self.build_refresh_request()
             if auth_response.status_code == 401:
                 raise AuthenticationError(
-                    "Not authenticated. Please run `qnx login` in your terminal."
+                    "Not authenticated. Please run qnx.login()."
                 )
 
             auth_response.raise_for_status()
@@ -67,6 +68,8 @@ class AuthHandler(httpx.Auth):
     def build_refresh_request(self) -> httpx.Request:
         """Build the request for refreshing the id token."""
         self.cookies.delete("myqos_id")  # We need to delete the existing token first
+        print("Building refresh request")
+        print(self.cookies)
         return httpx.Request(
             method="POST",
             url=f"{get_config().url}/auth/tokens/refresh",
@@ -99,3 +102,7 @@ def reload_client() -> None:
         timeout=None,
         verify=get_config().httpx_verify,
     )
+    
+    print("Reloaded client")
+    print(_nexus_client.auth.cookies)
+    print(get_nexus_client().auth.cookies)

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -18,10 +18,11 @@ from qnexus.config import get_config
 
 console = Console()
 
-_auth_client = httpx.Client(
-    base_url=f"{get_config().url}/auth", timeout=None, verify=get_config().httpx_verify
-)
-
+def _load_auth_client() -> httpx.Client:
+    """Get the auth client."""
+    return httpx.Client(
+        base_url=f"{get_config().url}/auth", timeout=None, verify=get_config().httpx_verify
+    )
 
 def login() -> None:
     """
@@ -30,7 +31,7 @@ def login() -> None:
     (if web browser can't be launched, displays the link)
     """
 
-    res = _auth_client.post(
+    res = _load_auth_client().post(
         "/device/device_authorization",
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         data={"client_id": "scales", "scope": "myqos"},
@@ -72,7 +73,7 @@ def login() -> None:
     while polling_for_seconds < expires_in:
         time.sleep(poll_interval)
         polling_for_seconds += poll_interval
-        resp = _auth_client.post(
+        resp = _load_auth_client().post(
             "/device/token",
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             data=token_request_body,
@@ -139,7 +140,7 @@ def _request_tokens(user: EmailStr, pwd: str) -> None:
     """Method to send login request to Nexus auth api and save tokens."""
     body = {"email": user, "password": pwd}
     try:
-        resp = _auth_client.post(
+        resp = _load_auth_client().post(
             "/login",
             json=body,
         )
@@ -149,7 +150,7 @@ def _request_tokens(user: EmailStr, pwd: str) -> None:
             mfa_code = input("Enter your MFA verification code: ")
             body["code"] = mfa_code
             body.pop("password")
-            resp = _auth_client.post(
+            resp = _load_auth_client().post(
                 "/mfa_challenge",
                 json=body,
             )


### PR DESCRIPTION
This PR aims to address two issues:

1. Internal users should be able to adjust the Nexus domain dynamically, allowing them to switch between different Nexus environments easily and without having to restart their interpreter/kernel.
2. All users should be able to login and use the generated tokens immediately to make requests to the Nexus service, without having to restart their interpreter/kernel.