### PR TITLE
fix: change domain, reload tokens dynamically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,12 @@ jobs:
 
       - name: Test with pytest
         run: |
-          uv run pytest tests/ --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
+          uv run pytest tests/test_auth.py::test_token_refresh --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
+          uv run pytest tests/test_auth.py::test_nexus_client_reloads_tokens --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
+          uv run pytest tests/test_auth.py::test_nexus_client_reloads_domain --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
+          uv run pytest tests/test_auth.py::test_token_refresh_expired --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
+
+          uv run pytest tests/ -v --ignore=tests/test_auth.py --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@master

--- a/README.md
+++ b/README.md
@@ -100,11 +100,19 @@ uv run pytest integration/
 These will only be available to run via Github CI by internal team members. For external contributions we recommend writing unit tests and/or integration tests and requesting they
 be run by an internal reviewer.
 
-Run basic unit tests using
+Unit tests can be run with:
 
 ```sh
-uv run pytest tests/
+uv run scripts/run_unit_tests.sh
 ```
+
+or to run via devenv script:
+
+```sh
+qtest
+```
+
+As some auth tests these manipulate environment variables they are currently run in isolation via the script.
 
 ### Release
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -22,6 +22,11 @@ in
     uv run ruff format 
     uv run mypy qnexus/ tests/ integration/
   '';
+  scripts.qtest.exec = ''
+    echo -e "Running unit tests  📏🔍\n"
+
+    uv run scripts/run_unit_tests.sh
+  '';
 
   enterShell = ''
     export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -11,14 +11,14 @@ from pytket.circuit import Circuit
 from pytket.wasm.wasm import WasmFileHandler
 
 import qnexus as qnx
-from qnexus.config import get_config
+from qnexus.config import CONFIG
 from qnexus.models.references import CircuitRef
 
 
 @contextmanager
 def make_authenticated_nexus(
-    user_email: str = get_config().qa_user_email,
-    user_password: str = get_config().qa_user_password,
+    user_email: str = CONFIG.qa_user_email,
+    user_password: str = CONFIG.qa_user_password,
 ) -> Generator[None, None, None]:
     """Authenticate the qnexus client."""
     try:

--- a/integration/setup_tokens.py
+++ b/integration/setup_tokens.py
@@ -1,6 +1,6 @@
 """Script to setup tokens in the testing environment."""
 
 import qnexus as qnx
-from qnexus.config import get_config
+from qnexus.config import CONFIG
 
-qnx.auth._request_tokens(get_config().qa_user_email, get_config().qa_user_password)
+qnx.auth._request_tokens(CONFIG.qa_user_email, CONFIG.qa_user_password)

--- a/integration/test_assignments.py
+++ b/integration/test_assignments.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import pandas as pd
 
 import qnexus as qnx
-from qnexus.config import get_config
+from qnexus.config import CONFIG
 from qnexus.models import Role
 from qnexus.models.references import TeamRef, UserRef
 
@@ -67,7 +67,7 @@ def test_user_assignment(
 
     qnx.roles.assign_user(
         resource_ref=new_project_ref,
-        user_email=get_config().qa_user_email,
+        user_email=CONFIG.qa_user_email,
         role="Contributor",
     )
 

--- a/integration/test_auth_flows.py
+++ b/integration/test_auth_flows.py
@@ -4,8 +4,11 @@ from io import StringIO
 from typing import Any
 
 import pytest
+from httpx import ConnectError
 
 import qnexus as qnx
+from qnexus.client import get_nexus_client
+from qnexus.client.auth import login_no_interaction
 from qnexus.client.utils import read_token
 from qnexus.config import get_config
 from qnexus.exceptions import AuthenticationError
@@ -56,3 +59,35 @@ def test_credential_login_full_flow(
 @pytest.mark.skip(reason="Not implemented")
 def test_device_code_flow_login_full_flow() -> None:
     """Test the flow for logging in with the browser."""
+
+
+def test_domain_switch(
+    monkeypatch: Any,
+) -> None:
+    """Set that we can reset the domain, login and not
+    for tokens/URL to be dynamically loaded."""
+
+    username = get_config().qa_user_email
+    pwd = get_config().qa_user_password
+
+    login_no_interaction(username, pwd)
+
+    qnx.users.get_self()
+
+    original_domain = get_config().domain
+
+    # fake domain will reset the client value
+    qnx.logout()
+    fake_domain = "fake_nexus.com"
+    monkeypatch.setenv("NEXUS_DOMAIN", fake_domain)
+    assert fake_domain in str(get_nexus_client(reload=True).base_url)
+
+    with pytest.raises(ConnectError):
+        qnx.users.get_self()
+
+    # setting it again will update the client without any restart required
+    monkeypatch.setenv("NEXUS_DOMAIN", original_domain)
+    login_no_interaction(username, pwd)
+    assert original_domain in str(get_nexus_client().base_url)
+
+    qnx.users.get_self()

--- a/integration/test_auth_flows.py
+++ b/integration/test_auth_flows.py
@@ -10,7 +10,7 @@ import qnexus as qnx
 from qnexus.client import get_nexus_client
 from qnexus.client.auth import login_no_interaction
 from qnexus.client.utils import read_token
-from qnexus.config import get_config
+from qnexus.config import CONFIG
 from qnexus.exceptions import AuthenticationError
 
 
@@ -19,8 +19,8 @@ def test_credential_login_full_flow(
 ) -> None:
     """Test that we can delete access tokens, login using credentials and
     delete tokens once again."""
-    username = get_config().qa_user_email
-    pwd = get_config().qa_user_password
+    username = CONFIG.qa_user_email
+    pwd = CONFIG.qa_user_password
 
     qnx.logout()
     with pytest.raises(FileNotFoundError):
@@ -67,14 +67,14 @@ def test_domain_switch(
     """Set that we can reset the domain, login and not
     for tokens/URL to be dynamically loaded."""
 
-    username = get_config().qa_user_email
-    pwd = get_config().qa_user_password
+    username = CONFIG.qa_user_email
+    pwd = CONFIG.qa_user_password
 
     login_no_interaction(username, pwd)
 
     qnx.users.get_self()
 
-    original_domain = get_config().domain
+    original_domain = CONFIG.domain
 
     # fake domain will reset the client value
     qnx.logout()

--- a/qnexus/client/__init__.py
+++ b/qnexus/client/__init__.py
@@ -5,7 +5,7 @@ import typing
 import httpx
 
 from qnexus.client.utils import read_token, write_token
-from qnexus.config import get_config
+from qnexus.config import CONFIG
 from qnexus.exceptions import AuthenticationError
 
 
@@ -25,9 +25,9 @@ class AuthHandler(httpx.Auth):
         try:
             self.cookies.clear()
             token = read_token("refresh_token")
-            self.cookies.set("myqos_oat", token, domain=get_config().domain)
+            self.cookies.set("myqos_oat", token, domain=CONFIG.domain)
             id_token = read_token("access_token")
-            self.cookies.set("myqos_id", id_token, domain=get_config().domain)
+            self.cookies.set("myqos_id", id_token, domain=CONFIG.domain)
         except FileNotFoundError:
             pass
 
@@ -42,7 +42,7 @@ class AuthHandler(httpx.Auth):
                     token = read_token(
                         "refresh_token",
                     )
-                    self.cookies.set("myqos_oat", token, domain=get_config().domain)
+                    self.cookies.set("myqos_oat", token, domain=CONFIG.domain)
                 except FileNotFoundError as exc:
                     raise AuthenticationError(
                         "Not authenticated. Please run `qnx login` in your terminal."
@@ -59,7 +59,7 @@ class AuthHandler(httpx.Auth):
 
             write_token(
                 "access_token",
-                self.cookies.get("myqos_id", domain=get_config().domain) or "",
+                self.cookies.get("myqos_id", domain=CONFIG.domain) or "",
             )
             if request.headers.get("cookie"):
                 request.headers.pop("cookie")
@@ -71,7 +71,7 @@ class AuthHandler(httpx.Auth):
         self.cookies.delete("myqos_id")  # We need to delete any existing id token first
         return httpx.Request(
             method="POST",
-            url=f"{get_config().url}/auth/tokens/refresh",
+            url=f"{CONFIG.url}/auth/tokens/refresh",
             cookies=self.cookies,
         )
 
@@ -92,9 +92,9 @@ def get_nexus_client(reload: bool = False) -> httpx.Client:
         _auth_handler.reload_tokens()
 
         _nexus_client = httpx.Client(
-            base_url=get_config().url,
+            base_url=CONFIG.url,
             auth=_auth_handler,
             timeout=None,
-            verify=get_config().httpx_verify,
+            verify=CONFIG.httpx_verify,
         )
     return _nexus_client

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -12,15 +12,20 @@ from rich.console import Console
 from rich.panel import Panel
 
 import qnexus.exceptions as qnx_exc
-from qnexus.client import reload_client
+from qnexus.client import get_nexus_client
 from qnexus.client.utils import consolidate_error, remove_token, write_token
 from qnexus.config import get_config
 
 console = Console()
 
-_auth_client = httpx.Client(
-    base_url=f"{get_config().url}/auth", timeout=None, verify=get_config().httpx_verify
-)
+
+def _get_auth_client() -> httpx.Client:
+    """Getter function for the Nexus auth client."""
+    return httpx.Client(
+        base_url=f"{get_config().url}/auth",
+        timeout=None,
+        verify=get_config().httpx_verify,
+    )
 
 
 def login() -> None:
@@ -30,7 +35,7 @@ def login() -> None:
     (if web browser can't be launched, displays the link)
     """
 
-    res = _auth_client.post(
+    res = _get_auth_client().post(
         "/device/device_authorization",
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         data={"client_id": "scales", "scope": "myqos"},
@@ -72,7 +77,7 @@ def login() -> None:
     while polling_for_seconds < expires_in:
         time.sleep(poll_interval)
         polling_for_seconds += poll_interval
-        resp = _auth_client.post(
+        resp = _get_auth_client().post(
             "/device/token",
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             data=token_request_body,
@@ -91,6 +96,7 @@ def login() -> None:
                 "access_token",
                 resp_json["access_token"],
             )
+            get_nexus_client(reload=True)
             # spinner.stop()
             print(
                 f"✅ Successfully logged in as {resp_json['email']} using the browser."
@@ -99,8 +105,6 @@ def login() -> None:
         # Fail for all other statuses
         consolidate_error(res=resp, description="Browser Login")
         # spinner.stop()
-
-        reload_client()
 
         return
     raise qnx_exc.AuthenticationError("Browser login Failed, code has expired.")
@@ -113,7 +117,6 @@ def login_with_credentials() -> None:
 
     _request_tokens(user=user_name, pwd=pwd)
 
-    reload_client()
     print(f"✅ Successfully logged in as {user_name}.")
 
 
@@ -123,7 +126,6 @@ def login_no_interaction(user: EmailStr, pwd: str) -> None:
     """
     _request_tokens(user=user, pwd=pwd)
 
-    reload_client()
     print(f"✅ Successfully logged in as {user}.")
 
 
@@ -131,7 +133,6 @@ def logout() -> None:
     """Clear tokens from file system and the client."""
     remove_token("refresh_token")
     remove_token("access_token")
-    reload_client()
     print("Successfully logged out.")
 
 
@@ -139,7 +140,7 @@ def _request_tokens(user: EmailStr, pwd: str) -> None:
     """Method to send login request to Nexus auth api and save tokens."""
     body = {"email": user, "password": pwd}
     try:
-        resp = _auth_client.post(
+        resp = _get_auth_client().post(
             "/login",
             json=body,
         )
@@ -149,7 +150,7 @@ def _request_tokens(user: EmailStr, pwd: str) -> None:
             mfa_code = input("Enter your MFA verification code: ")
             body["code"] = mfa_code
             body.pop("password")
-            resp = _auth_client.post(
+            resp = _get_auth_client().post(
                 "/mfa_challenge",
                 json=body,
             )
@@ -175,6 +176,7 @@ def _request_tokens(user: EmailStr, pwd: str) -> None:
 
         write_token("refresh_token", myqos_oat)
         write_token("access_token", myqos_id)
+        get_nexus_client(reload=True)
 
     finally:
         del user

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -14,7 +14,7 @@ from rich.panel import Panel
 import qnexus.exceptions as qnx_exc
 from qnexus.client import get_nexus_client
 from qnexus.client.utils import consolidate_error, remove_token, write_token
-from qnexus.config import get_config
+from qnexus.config import CONFIG
 
 console = Console()
 
@@ -22,9 +22,9 @@ console = Console()
 def _get_auth_client() -> httpx.Client:
     """Getter function for the Nexus auth client."""
     return httpx.Client(
-        base_url=f"{get_config().url}/auth",
+        base_url=f"{CONFIG.url}/auth",
         timeout=None,
-        verify=get_config().httpx_verify,
+        verify=CONFIG.httpx_verify,
     )
 
 

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -133,6 +133,7 @@ def logout() -> None:
     """Clear tokens from file system and the client."""
     remove_token("refresh_token")
     remove_token("access_token")
+    get_nexus_client(reload=True)
     print("Successfully logged out.")
 
 

--- a/qnexus/client/jobs/__init__.py
+++ b/qnexus/client/jobs/__init__.py
@@ -19,7 +19,7 @@ from qnexus.client import get_nexus_client
 from qnexus.client.jobs import _compile, _execute
 from qnexus.client.nexus_iterator import NexusIterator
 from qnexus.client.utils import handle_fetch_errors
-from qnexus.config import get_config
+from qnexus.config import CONFIG
 from qnexus.context import (
     get_active_project,
     merge_project_from_context,
@@ -327,7 +327,7 @@ async def listen_job_status(
     # If we pass True into the websocket connection, it sets a default SSLContext.
     # See: https://websockets.readthedocs.io/en/stable/reference/client.html
     ssl_reconfigured: Union[bool, ssl.SSLContext] = True
-    if not get_config().httpx_verify:
+    if not CONFIG.httpx_verify:
         ssl_reconfigured = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ssl_reconfigured.check_hostname = False
         ssl_reconfigured.verify_mode = ssl.CERT_NONE
@@ -337,7 +337,7 @@ async def listen_job_status(
         "Cookie": f"myqos_id={get_nexus_client().auth.cookies.get('myqos_id')}"  # type: ignore
     }
     async for websocket in connect(
-        f"{get_config().websockets_url}/api/jobs/v1beta2/{job.id}/attributes/status/ws",
+        f"{CONFIG.websockets_url}/api/jobs/v1beta2/{job.id}/attributes/status/ws",
         ssl=ssl_reconfigured,
         extra_headers=extra_headers,
         # logger=logger,

--- a/qnexus/client/utils.py
+++ b/qnexus/client/utils.py
@@ -10,7 +10,7 @@ from httpx import Response
 from pydantic import BaseModel
 
 import qnexus.exceptions as qnx_exc
-from qnexus.config import get_config
+from qnexus.config import CONFIG
 
 TokenTypes = Literal["access_token", "refresh_token"]
 
@@ -44,7 +44,7 @@ def remove_token(token_type: TokenTypes) -> None:
     if is_jupyterhub_environment() and token_type == "refresh_token":
         return
     token_file_path = (
-        Path.home() / get_config().token_path / token_file_from_type[token_type]
+        Path.home() / CONFIG.token_path / token_file_from_type[token_type]
     )
     if token_file_path.exists():
         token_file_path.unlink()
@@ -77,7 +77,7 @@ class AccessToken(BaseModel):
 
 def read_token(token_type: TokenTypes) -> str:
     """Read a token from a file."""
-    token_file_path = Path.home() / get_config().token_path
+    token_file_path = Path.home() / CONFIG.token_path
     with (token_file_path / token_file_from_type[token_type]).open(
         encoding="UTF-8"
     ) as file:
@@ -94,7 +94,7 @@ def write_token(token_type: TokenTypes, token: str) -> None:
     if is_jupyterhub_environment() and token_type == "refresh_token":
         return
 
-    token_file_path = Path.home() / get_config().token_path
+    token_file_path = Path.home() / CONFIG.token_path
     token_file_path.mkdir(parents=True, exist_ok=True)
     with (token_file_path / token_file_from_type[token_type]).open(
         encoding="UTF-8", mode="w"

--- a/qnexus/client/utils.py
+++ b/qnexus/client/utils.py
@@ -43,9 +43,7 @@ def remove_token(token_type: TokenTypes) -> None:
     # Don't try to delete refresh token in Jupyterhub
     if is_jupyterhub_environment() and token_type == "refresh_token":
         return
-    token_file_path = (
-        Path.home() / CONFIG.token_path / token_file_from_type[token_type]
-    )
+    token_file_path = Path.home() / CONFIG.token_path / token_file_from_type[token_type]
     if token_file_path.exists():
         token_file_path.unlink()
 

--- a/qnexus/config.py
+++ b/qnexus/config.py
@@ -22,7 +22,7 @@ class Config(BaseSettings):
     httpx_verify: bool = True
 
     # auth
-    store_tokens: bool = True
+    store_tokens: bool = True  # Not implemented
     token_path: str = ".qnx/auth"
 
     # testing

--- a/qnexus/config.py
+++ b/qnexus/config.py
@@ -9,6 +9,11 @@ class Config(BaseSettings):
 
     Uses pydantic-settings to read environment variables for qnexus configuration."""
 
+    def __init__(self, *args, **kwargs):
+        """Initialize the config object."""
+        print("Initializing qnexus config")
+        super().__init__(*args, **kwargs)
+
     model_config = SettingsConfigDict(env_prefix="NEXUS_")
 
     # web
@@ -43,7 +48,4 @@ class Config(BaseSettings):
         """Current websockets API URL"""
         return f"{self.websockets_protocol}://{self.domain}"
 
-
-def get_config() -> Config:
-    """Get config"""
-    return Config()
+CONFIG = Config()

--- a/qnexus/config.py
+++ b/qnexus/config.py
@@ -9,11 +9,6 @@ class Config(BaseSettings):
 
     Uses pydantic-settings to read environment variables for qnexus configuration."""
 
-    def __init__(self, *args, **kwargs):
-        """Initialize the config object."""
-        print("Initializing qnexus config")
-        super().__init__(*args, **kwargs)
-
     model_config = SettingsConfigDict(env_prefix="NEXUS_")
 
     # web
@@ -47,5 +42,6 @@ class Config(BaseSettings):
     def websockets_url(self) -> str:
         """Current websockets API URL"""
         return f"{self.websockets_protocol}://{self.domain}"
+
 
 CONFIG = Config()

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Stop on first error
+set -e
+
+# Order doesn't matter but auth tests manipulate environment variables
+# and should be run separately
+uv run pytest tests/test_auth.py::test_token_refresh
+uv run pytest tests/test_auth.py::test_nexus_client_reloads_tokens
+uv run pytest tests/test_auth.py::test_nexus_client_reloads_domain
+uv run pytest tests/test_auth.py::test_token_refresh_expired
+
+
+echo "Running non-auth tests"
+uv run pytest tests/ -v --ignore=tests/test_auth.py
+
+echo -e "\n🎉 All tests passed successfully!"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,25 +1,54 @@
-"""Test the token-based auth logic for the httpx Client."""
+"""Test the token-based auth logic for the httpx Client.
+
+N.B. these manipulate environment variables so currently run in isolation via scripts/run_unit_test.sh.
+"""
+
+from typing import Any, Generator
 
 import httpx
 import pytest
 import respx
 
 import qnexus as qnx
-from qnexus.client import get_nexus_client
-from qnexus.client.utils import read_token, write_token
-from qnexus.config import get_config
+from qnexus.client import _nexus_client, get_nexus_client
+from qnexus.client.utils import read_token, remove_token, write_token
 from qnexus.exceptions import AuthenticationError
+
+
+@pytest.fixture(autouse=True)
+def clean_token_state() -> Generator[Any, Any, Any]:
+    """Clean up token state before and after each test."""
+    # Setup - clean token files
+    remove_token("refresh_token")
+    remove_token("access_token")
+    global _nexus_client
+    if _nexus_client is not None:
+        _nexus_client.close()
+        _nexus_client = None
+
+    yield  # Run the test
+
+    # Teardown - clean up after test
+    remove_token("refresh_token")
+    remove_token("access_token")
+    if _nexus_client is not None:
+        _nexus_client.close()
+        _nexus_client = None
 
 
 @respx.mock
 def test_token_refresh() -> None:
-    """Test the auth refresh logic, using in-memory token storage."""
+    """Test the auth refresh logic, using in-memory token storage.
 
-    get_config().store_tokens = False
+    Test that we can refresh the access token using the refresh token
+    and that the new access token is used in subsequent requests.
+    """
+
+    old_id_token = "dummy_id"
+    refreshed_access_token = "new_dummy_id"
 
     write_token("refresh_token", "dummy_oat")
-    write_token("access_token", "dummy_id")
-    refreshed_access_token = "new_dummy_id"
+    write_token("access_token", old_id_token)
 
     # Mock the list projects endpoint to force a refresh
     list_project_route = respx.get(
@@ -53,12 +82,17 @@ def test_token_refresh() -> None:
     assert read_token("access_token") == refreshed_access_token
     assert get_nexus_client().auth.cookies.get("myqos_id") == refreshed_access_token  # type: ignore
 
+    # confirm that the request headers were updated
+    first_cookie_header = list_project_route.calls[0].request.headers["cookie"]
+    assert f"myqos_id={old_id_token}" in first_cookie_header
+
+    last_cookie_header = list_project_route.calls[-1].request.headers["cookie"]
+    assert f"myqos_id={refreshed_access_token}" in last_cookie_header
+
 
 @respx.mock
 def test_token_refresh_expired() -> None:
     """Test the case of an expired refresh token, using in-memory token storage."""
-
-    get_config().store_tokens = False
 
     write_token("refresh_token", "dummy_oat")
     write_token("access_token", "dummy_id")
@@ -78,3 +112,57 @@ def test_token_refresh_expired() -> None:
 
     assert list_project_route.called
     assert refresh_token_route.called
+
+
+def test_nexus_client_reloads_tokens() -> None:
+    """Test the reload functionality of the nexus client.
+
+    Test that if we write new tokens and reload the client,
+    that the new tokens are used."""
+
+    oat_one = "dummy_oat_one"
+    oat_two = "dummy_oat_two"
+
+    write_token("refresh_token", oat_one)
+    client_one = get_nexus_client(reload=True)
+    assert client_one.auth.cookies.get("myqos_oat") == oat_one  # type: ignore
+
+    write_token("refresh_token", oat_two)
+    client_two = get_nexus_client()
+    assert client_two.auth.cookies.get("myqos_oat") == oat_one  # type: ignore
+
+    client_two = get_nexus_client(reload=True)
+    assert client_two.auth.cookies.get("myqos_oat") == oat_two  # type: ignore
+
+
+def test_nexus_client_reloads_domain(monkeypatch: Any) -> None:
+    """Test the reload functionality of the nexus client.
+    We should be able to change the domain in the environment
+    and have the client reload with the new domain obtainable
+    via a getter function.
+    """
+
+    domain_one = "dummy_domain_one.com"
+    domain_two = "dummy_domain_two.com"
+
+    monkeypatch.setenv("NEXUS_DOMAIN", domain_one)
+    # mock login
+    write_token("refresh_token", "dummy_oat")
+    write_token("access_token", "dummy_id")
+
+    client_one = get_nexus_client(reload=True)
+    client_two = get_nexus_client(reload=True)
+
+    assert domain_one in str(client_one.base_url)
+    assert domain_one in str(client_two.base_url)
+
+    monkeypatch.setenv("NEXUS_DOMAIN", domain_two)
+
+    assert domain_two not in str(client_one.base_url)
+    assert domain_two not in str(client_two.base_url)
+
+    client_two = get_nexus_client(reload=True)
+    # client_two getter should not effect client_one
+    assert domain_two not in str(client_one.base_url)
+    # client_two getter should reload the client
+    assert domain_two in str(client_two.base_url)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,6 +2,7 @@
 
 N.B. these manipulate environment variables so currently run in isolation via scripts/run_unit_test.sh.
 """
+
 from typing import Any, Generator
 from uuid import uuid4
 
@@ -10,9 +11,9 @@ import pytest
 import respx
 
 import qnexus as qnx
-from qnexus.config import CONFIG
 from qnexus.client import _nexus_client, get_nexus_client
 from qnexus.client.utils import read_token, remove_token, write_token
+from qnexus.config import CONFIG
 from qnexus.exceptions import AuthenticationError
 
 
@@ -87,11 +88,9 @@ def test_token_refresh() -> None:
     assert get_nexus_client().auth.cookies.get("myqos_id") == refreshed_access_token  # type: ignore
 
     # confirm that the request headers were updated
-    print(list_project_route.calls[0].request.headers)
     first_cookie_header = list_project_route.calls[0].request.headers["cookie"]
     assert f"myqos_id={old_id_token}" in first_cookie_header
 
-    print(list_project_route.calls[-1].request.headers)
     last_cookie_header = list_project_route.calls[-1].request.headers["cookie"]
     assert f"myqos_id={refreshed_access_token}" in last_cookie_header
 


### PR DESCRIPTION
This PR aims to address two issues:

1. Internal users should be able to adjust the Nexus domain dynamically, allowing them to switch between different Nexus environments easily and without having to restart their interpreter/kernel.
2. All users should be able to login and use the generated tokens immediately to make requests to the Nexus service, without having to restart their interpreter/kernel.


Expected behaviour:

1. user should be able to do some python and then make a qnexus request that fails for one of two reasons: (a) auth tokens aren't present or (b) auth tokens are invalid.
2. Optional: the user adjusts the NEXUS_DOMAIN environment variable via:
`os.environ["NEXUS_DOMAIN"] = "nexus-other-site.com"`
3. The user should be able to `qnx.login()` (or any login flow) and then repeat the request, which should succeed (for the NEXUS_DOMAIN of interest).

Happy to discuss further.
