### PR TITLE
fix: handle the case when get_passes is called on a CompilationResultRef without any passes.

### DIFF
--- a/examples/basics/jobs_results.ipynb
+++ b/examples/basics/jobs_results.ipynb
@@ -69,6 +69,7 @@
     "    optimisation_level=1,\n",
     "    backend_config=qnx.QuantinuumConfig(device_name=\"H1-1LE\"),\n",
     "    project=my_project_ref,\n",
+    "    skip_intermediate_circuits=False, # Store compiled circuits\n",
     ")\n",
     "\n",
     "# Block until the job is complete (or perform other tasks while we wait)\n",

--- a/examples/basics/jobs_results.ipynb
+++ b/examples/basics/jobs_results.ipynb
@@ -69,7 +69,7 @@
     "    optimisation_level=1,\n",
     "    backend_config=qnx.QuantinuumConfig(device_name=\"H1-1LE\"),\n",
     "    project=my_project_ref,\n",
-    "    skip_intermediate_circuits=False, # Store compiled circuits\n",
+    "    skip_intermediate_circuits=False,  # Store compiled circuits\n",
     ")\n",
     "\n",
     "# Block until the job is complete (or perform other tasks while we wait)\n",

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -75,6 +75,7 @@ def _authenticated_nexus(
             description=test_desc,
             project=my_proj,
             backend_config=qnx.AerConfig(),
+            skip_intermediate_circuits=False,
         )
 
         execute_job_ref = qnx.start_execute_job(

--- a/integration/test_jobs.py
+++ b/integration/test_jobs.py
@@ -115,6 +115,7 @@ def test_submit_compile(
         name=f"qnexus_integration_test_compile_job_{datetime.now()}",
         project=my_proj,
         backend_config=config,
+        skip_intermediate_circuits=False,
     )
 
     assert isinstance(compile_job_ref, CompileJobRef)

--- a/qnexus/client/quotas.py
+++ b/qnexus/client/quotas.py
@@ -30,7 +30,11 @@ def get_all() -> DataframableList[Quota]:
 
     quota_list: DataframableList[Quota] = DataframableList([])
     for quota in res.json():
-        quota_key = _quota_map[quota["quota"]["name"]]
+        try:
+            quota_key = _quota_map[quota["quota"]["name"]]
+        except KeyError:
+            # If the quota name is not in the map, skip it
+            continue
         quota_value = quota["quota"]["details"].get(quota_key, None)
         quota_list.append(
             Quota(

--- a/qnexus/models/references.py
+++ b/qnexus/models/references.py
@@ -334,25 +334,21 @@ class CompilationResultRef(BaseRef):
         return self._output_circuit
 
     def get_passes(self) -> DataframableList[CompilationPassRef]:
-        """Get information on the compilation passes and the output circuits."""
+        """Get information on the compilation passes and the output circuits (if available)."""
         if self._compilation_passes:
             return copy(self._compilation_passes)
 
-        (
-            self._compilation_passes,
-            self._input_circuit,
-            self._output_circuit,
-        ) = self._get_compile_results()
+        self._compilation_passes = self._get_compile_results()
         return copy(self._compilation_passes)
 
     def _get_compile_results(
         self,
-    ) -> tuple[DataframableList[CompilationPassRef], CircuitRef, CircuitRef]:
+    ) -> DataframableList[CompilationPassRef]:
         """Utility method to retrieve the passes and output circuit."""
         from qnexus.client.jobs._compile import _fetch_compilation_passes
 
         passes = _fetch_compilation_passes(self)
-        return (passes, passes[0].input_circuit, passes[-1].output_circuit)
+        return passes
 
     def df(self) -> pd.DataFrame:
         """Present in a pandas DataFrame."""


### PR DESCRIPTION
Also noted a spot where new quotas would cause breakage.

Should fix the integration tests.