### PR TITLE
feat!: move to the latest jobs API in Nexus

### DIFF
--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -70,7 +70,7 @@ def _authenticated_nexus(
         )
 
         compile_job_ref = qnx.start_compile_job(
-            circuits=[my_other_circuit],
+            programs=[my_other_circuit],
             name=qa_compile_job_name,
             description=test_desc,
             project=my_proj,
@@ -79,7 +79,7 @@ def _authenticated_nexus(
         )
 
         execute_job_ref = qnx.start_execute_job(
-            circuits=[my_new_circuit],
+            programs=[my_new_circuit],
             name=qa_execute_job_name,
             description=test_desc,
             project=my_proj,

--- a/integration/test_jobs.py
+++ b/integration/test_jobs.py
@@ -111,7 +111,7 @@ def test_submit_compile(
     config = qnx.AerConfig()
 
     compile_job_ref = qnx.start_compile_job(
-        circuits=[_authenticated_nexus_circuit_ref],
+        programs=[_authenticated_nexus_circuit_ref],
         name=f"qnexus_integration_test_compile_job_{datetime.now()}",
         project=my_proj,
         backend_config=config,
@@ -150,7 +150,7 @@ def test_compile(
     my_proj = qnx.projects.get(name_like=qa_project_name)
 
     compiled_circuits = qnx.compile(
-        circuits=[_authenticated_nexus_circuit_ref],
+        programs=[_authenticated_nexus_circuit_ref],
         name=f"qnexus_integration_test_compile_job_{datetime.now()}",
         project=my_proj,
         backend_config=qnx.AerConfig(),
@@ -170,7 +170,7 @@ def test_get_results_for_incomplete_compile(
     my_proj = qnx.projects.get(name_like=qa_project_name)
 
     compile_job_ref = qnx.start_compile_job(
-        circuits=[_authenticated_nexus_circuit_ref],
+        programs=[_authenticated_nexus_circuit_ref],
         name=f"qnexus_integration_test_compile_job_{datetime.now()}",
         project=my_proj,
         backend_config=qnx.AerConfig(),
@@ -190,7 +190,7 @@ def test_compile_hypertket(
     my_proj = qnx.projects.get(name_like=qa_project_name)
 
     compiled_circuits = qnx.compile(
-        circuits=[_authenticated_nexus_circuit_ref],
+        programs=[_authenticated_nexus_circuit_ref],
         name=f"qnexus_integration_test_compile_job_{datetime.now()}",
         project=my_proj,
         backend_config=qnx.QuantinuumConfig(device_name="H1-1LE"),
@@ -215,7 +215,7 @@ def test_submit_execute(
     my_circ = qnx.circuits.get(name_like=qa_circuit_name, project=my_proj)
 
     execute_job_ref = qnx.start_execute_job(
-        circuits=[my_circ],
+        programs=[my_circ],
         name=f"qnexus_integration_test_execute_job_{datetime.now()}",
         project=my_proj,
         backend_config=config,
@@ -251,7 +251,7 @@ def test_execute(
     my_circ = qnx.circuits.get(name_like=qa_circuit_name, project=my_proj)
 
     backend_results = qnx.execute(
-        circuits=[my_circ],
+        programs=[my_circ],
         name=f"qnexus_integration_test_execute_job_{datetime.now()}",
         project=my_proj,
         backend_config=qnx.AerConfig(),
@@ -281,7 +281,7 @@ def test_get_results_for_incomplete_execute(
     )
 
     execute_job_ref = qnx.start_execute_job(
-        circuits=[my_circ, my_q_systems_circuit],
+        programs=[my_circ, my_q_systems_circuit],
         name=f"qnexus_integration_test_execute_job_{datetime.now()}",
         project=my_proj,
         backend_config=qnx.QuantinuumConfig(device_name="H1-1LE"),
@@ -323,7 +323,7 @@ def test_wait_for_raises_on_job_error(
     my_circ = qnx.circuits.get(name_like=qa_circuit_name, project=my_proj)
 
     failing_job_ref = qnx.start_execute_job(
-        circuits=[my_circ],
+        programs=[my_circ],
         name=f"qnexus_integration_test_failing_job_{datetime.now()}",
         project=my_proj,
         n_shots=[10],
@@ -347,7 +347,7 @@ def test_results_not_available_error(
     my_proj = qnx.projects.get(name_like=qa_project_name)
     my_circ = qnx.circuits.get(name_like=qa_circuit_name, project=my_proj)
     execute_job_ref = qnx.start_execute_job(
-        circuits=[my_circ],
+        programs=[my_circ],
         name=f"qnexus_integration_test_waiting_job_{datetime.now()}",
         project=my_proj,
         backend_config=qnx.AerConfig(),
@@ -390,7 +390,7 @@ def test_submit_under_user_group(
 
     with pytest.raises(qnx_exc.ResourceCreateFailed) as exc:
         qnx.start_compile_job(
-            circuits=[_authenticated_nexus_circuit_ref],
+            programs=[_authenticated_nexus_circuit_ref],
             name=f"qnexus_integration_test_compile_job_{datetime.now()}",
             project=my_proj,
             backend_config=qnx.AerConfig(),
@@ -399,7 +399,7 @@ def test_submit_under_user_group(
         assert exc.value.message == f"Not a member of any group with name: {fake_group}"
 
     qnx.start_compile_job(
-        circuits=[_authenticated_nexus_circuit_ref],
+        programs=[_authenticated_nexus_circuit_ref],
         name=f"qnexus_integration_test_compile_job_{datetime.now()}",
         project=my_proj,
         backend_config=qnx.AerConfig(),
@@ -410,7 +410,7 @@ def test_submit_under_user_group(
 
     with pytest.raises(qnx_exc.ResourceCreateFailed):
         qnx.start_execute_job(
-            circuits=[my_circ],
+            programs=[my_circ],
             name=f"qnexus_integration_test_execute_job_{datetime.now()}",
             project=my_proj,
             backend_config=qnx.AerConfig(),
@@ -420,7 +420,7 @@ def test_submit_under_user_group(
         assert exc.value.message == f"Not a member of any group with name: {fake_group}"
 
     qnx.start_execute_job(
-        circuits=[my_circ],
+        programs=[my_circ],
         name=f"qnexus_integration_test_execute_job_{datetime.now()}",
         project=my_proj,
         backend_config=qnx.AerConfig(),

--- a/integration/test_qsys_jobs.py
+++ b/integration/test_qsys_jobs.py
@@ -66,7 +66,7 @@ def test_guppy_execution(
     )
 
     job_ref = qnx.start_execute_job(
-        circuits=[hugr_ref],
+        programs=[hugr_ref],
         n_shots=[n_shots],
         backend_config=qnx.QuantinuumConfig(device_name=qsys_qa_device_name),
         project=project_ref,

--- a/integration/test_wasm_modules.py
+++ b/integration/test_wasm_modules.py
@@ -81,7 +81,7 @@ def test_wasm_flow(
     )
 
     execute_job_ref = qnx.start_execute_job(
-        circuits=[wasm_circuit_ref],
+        programs=[wasm_circuit_ref],
         name=f"qnexus_integration_test_wasm_execute_job_{datetime.now()}",
         n_shots=[100],
         backend_config=qnx.QuantinuumConfig(

--- a/qnexus/__init__.py
+++ b/qnexus/__init__.py
@@ -1,5 +1,7 @@
 """The qnexus package."""
 
+import warnings
+
 import nest_asyncio  # type: ignore
 
 from qnexus import context, filesystem
@@ -33,6 +35,8 @@ from qnexus.models import (
     QuantinuumConfig,
     QulacsConfig,
 )
+
+warnings.filterwarnings("default", category=DeprecationWarning, module=__name__)
 
 # This is necessary for use in Jupyter notebooks to allow for nested asyncio loops
 try:

--- a/qnexus/client/jobs/__init__.py
+++ b/qnexus/client/jobs/__init__.py
@@ -18,7 +18,7 @@ import qnexus.exceptions as qnx_exc
 from qnexus.client import get_nexus_client
 from qnexus.client.jobs import _compile, _execute
 from qnexus.client.nexus_iterator import NexusIterator
-from qnexus.client.utils import handle_fetch_errors
+from qnexus.client.utils import accept_circuits_for_programs, handle_fetch_errors
 from qnexus.config import CONFIG
 from qnexus.context import (
     get_active_project,
@@ -445,6 +445,7 @@ def delete(job: JobRef) -> None:
         res.raise_for_status()
 
 
+@accept_circuits_for_programs
 @merge_properties_from_context
 def compile(
     programs: Union[CircuitRef, list[CircuitRef]],
@@ -488,6 +489,7 @@ def compile(
     )
 
 
+@accept_circuits_for_programs
 @merge_properties_from_context
 def execute(
     programs: Union[ExecutionProgram, list[ExecutionProgram]],

--- a/qnexus/client/jobs/_compile.py
+++ b/qnexus/client/jobs/_compile.py
@@ -8,6 +8,7 @@ from quantinuum_schemas.models.hypertket_config import HyperTketConfig
 import qnexus.exceptions as qnx_exc
 from qnexus.client import circuits as circuit_api
 from qnexus.client import get_nexus_client
+from qnexus.client.utils import accept_circuits_for_programs
 from qnexus.context import get_active_project, merge_properties_from_context
 from qnexus.models import BackendConfig
 from qnexus.models.annotations import Annotations, CreateAnnotations, PropertiesDict
@@ -22,6 +23,7 @@ from qnexus.models.references import (
 )
 
 
+@accept_circuits_for_programs
 @merge_properties_from_context
 def start_compile_job(
     programs: Union[CircuitRef, list[CircuitRef]],

--- a/qnexus/client/jobs/_compile.py
+++ b/qnexus/client/jobs/_compile.py
@@ -42,11 +42,17 @@ def start_compile_job(
     project = project or get_active_project(project_required=True)
     project = cast(ProjectRef, project)
 
-    program_ids = (
-        [str(programs.id)]
-        if isinstance(programs, CircuitRef)
-        else [str(p.id) for p in programs]
-    )
+    match programs:
+        case CircuitRef():
+            program_ids = [str(programs.id)]
+        case list():
+            if not all(isinstance(p, CircuitRef) for p in programs):
+                raise TypeError("Compile jobs only accept circuits")
+            program_ids = [str(p.id) for p in programs]
+        case _:
+            raise TypeError(
+                "Expected programs to be either a CircuitRef or a list of CircuitRefs"
+            )
 
     attributes_dict = CreateAnnotations(
         name=name,

--- a/qnexus/client/jobs/_execute.py
+++ b/qnexus/client/jobs/_execute.py
@@ -7,6 +7,7 @@ from pytket.backends.backendinfo import BackendInfo
 from pytket.backends.backendresult import BackendResult
 from pytket.backends.status import StatusEnum
 
+from qnexus.client.utils import accept_circuits_for_programs
 import qnexus.exceptions as qnx_exc
 from qnexus.client import circuits as circuit_api
 from qnexus.client import get_nexus_client
@@ -30,6 +31,7 @@ from qnexus.models.references import (
 from qnexus.models.utils import assert_never
 
 
+@accept_circuits_for_programs
 @merge_properties_from_context
 def start_execute_job(
     programs: Union[ExecutionProgram, list[ExecutionProgram]],

--- a/qnexus/client/jobs/_execute.py
+++ b/qnexus/client/jobs/_execute.py
@@ -32,7 +32,7 @@ from qnexus.models.utils import assert_never
 
 @merge_properties_from_context
 def start_execute_job(
-    circuits: Union[ExecutionProgram, list[ExecutionProgram]],
+    programs: Union[ExecutionProgram, list[ExecutionProgram]],
     n_shots: list[int] | list[None],
     backend_config: BackendConfig,
     name: str,
@@ -57,9 +57,9 @@ def start_execute_job(
     project = cast(ProjectRef, project)
 
     program_ids = (
-        [str(p.id) for p in circuits]
-        if isinstance(circuits, list)
-        else [str(circuits.id)]
+        [str(p.id) for p in programs]
+        if isinstance(programs, list)
+        else [str(programs.id)]
     )
 
     if len(n_shots) != len(program_ids):
@@ -87,7 +87,7 @@ def start_execute_job(
                 "wasm_module_id": str(wasm_module.id) if wasm_module else None,
                 "credential_name": credential_name,
                 "items": [
-                    {"circuit_id": program_id, "n_shots": n_shot}
+                    {"program_id": program_id, "n_shots": n_shot}
                     for program_id, n_shot in zip(program_ids, n_shots)
                 ],
             },
@@ -95,11 +95,6 @@ def start_execute_job(
     )
     relationships = {
         "project": {"data": {"id": str(project.id), "type": "project"}},
-        "circuits": {
-            "data": [
-                {"id": str(program_id), "type": "circuit"} for program_id in program_ids
-            ]
-        },
     }
     req_dict = {
         "data": {
@@ -110,7 +105,7 @@ def start_execute_job(
     }
 
     resp = get_nexus_client().post(
-        "/api/jobs/v1beta2",
+        "/api/jobs/v1beta3",
         json=req_dict,
     )
     if resp.status_code != 202:
@@ -135,7 +130,7 @@ def _results(
 ) -> DataframableList[ExecutionResultRef]:
     """Get the results from an execute job."""
 
-    resp = get_nexus_client().get(f"/api/jobs/v1beta2/{execute_job.id}")
+    resp = get_nexus_client().get(f"/api/jobs/v1beta3/{execute_job.id}")
 
     if resp.status_code != 200:
         raise qnx_exc.ResourceFetchFailed(

--- a/qnexus/client/utils.py
+++ b/qnexus/client/utils.py
@@ -146,12 +146,11 @@ def is_jupyterhub_environment() -> bool:
 
 
 ParamsWithProgramsOrCircuits = ParamSpec("ParamsWithProgramsOrCircuits")
-ParamsWithPrograms = ParamSpec("ParamsWithPrograms")
 ReturnType = TypeVar("ReturnType")
 
 
 def accept_circuits_for_programs(
-    fn: Callable[ParamsWithPrograms, ReturnType],
+    fn: Callable[ParamsWithProgramsOrCircuits, ReturnType],
 ) -> Callable[ParamsWithProgramsOrCircuits, ReturnType]:
     """
     Nexus's /api/jobs/v1beta3 introduces the concept of programs for compilation
@@ -174,6 +173,6 @@ def accept_circuits_for_programs(
                 category=DeprecationWarning,
             )
             del kwargs["circuits"]
-        return fn(*args, **kwargs)  # type: ignore
+        return fn(*args, **kwargs)
 
     return wrapper

--- a/qnexus/client/utils.py
+++ b/qnexus/client/utils.py
@@ -1,10 +1,12 @@
 """Utlity functions for the client."""
 
+from functools import wraps
 import http
 import json
 import os
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal, ParamSpec, TypeVar
+import warnings
 
 from httpx import Response
 from pydantic import BaseModel
@@ -141,3 +143,37 @@ def is_jupyterhub_environment() -> bool:
     if os.environ.get("JUPYTERHUB_USER"):
         return True
     return False
+
+
+ParamsWithProgramsOrCircuits = ParamSpec("ParamsWithProgramsOrCircuits")
+ParamsWithPrograms = ParamSpec("ParamsWithPrograms")
+ReturnType = TypeVar("ReturnType")
+
+
+def accept_circuits_for_programs(
+    fn: Callable[ParamsWithPrograms, ReturnType],
+) -> Callable[ParamsWithProgramsOrCircuits, ReturnType]:
+    """
+    Nexus's /api/jobs/v1beta3 introduces the concept of programs for compilation
+    and execution. This decorator shims from an argument called "circuits" to an
+    argument called "programs", emitting a deprecation warning if necessary, so
+    that the pre-existing qnexus python API can support both methods for a
+    while.
+    """
+
+    @wraps(fn)
+    def wrapper(
+        *args: ParamsWithProgramsOrCircuits.args,
+        **kwargs: ParamsWithProgramsOrCircuits.kwargs,
+    ) -> ReturnType:
+        if "circuits" in kwargs:
+            kwargs["programs"] = kwargs["circuits"]
+            warnings.warn(
+                "The `circuits` argument is deprecated and will be removed in a "
+                "future version. Please use `programs`.",
+                category=DeprecationWarning,
+            )
+            del kwargs["circuits"]
+        return fn(*args, **kwargs)  # type: ignore
+
+    return wrapper

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,96 @@
+import datetime as dt
+from typing import Union
+from unittest import mock
+from uuid import uuid4
+import warnings
+
+import pytest
+
+from qnexus.client.utils import accept_circuits_for_programs
+from qnexus.models.references import CircuitRef, ProjectRef
+from qnexus.client.jobs._compile import start_compile_job
+from qnexus import QuantinuumConfig
+
+PROJECT_REF = ProjectRef(
+    annotations={}, id=uuid4(), contents_modified=dt.datetime.now()
+)
+CIRCUIT_REF = CircuitRef(
+    id=uuid4(),
+    annotations={},
+    project=PROJECT_REF,
+)
+
+
+def test_wrapper() -> None:
+    """
+    Test that `accept_circuits_for_programs` decorator invokes the wrapped
+    function as expected, emitting a deprecation warning when the old `circuits`
+    keyword arg is used.
+    """
+
+    @accept_circuits_for_programs
+    def inner_fn(
+        name: str,
+        programs: Union[CircuitRef, list[CircuitRef]],
+    ) -> None:
+        assert programs == [CIRCUIT_REF]
+
+    with warnings.catch_warnings(record=True) as captured:
+        inner_fn("hello", [CIRCUIT_REF])
+        assert len(captured) == 0
+
+    with warnings.catch_warnings(record=True) as captured:
+        inner_fn("hello", circuits=[CIRCUIT_REF])
+        assert len(captured) == 1
+        assert captured[0].category == DeprecationWarning
+
+    with warnings.catch_warnings(record=True) as captured:
+        inner_fn("hello", programs=[CIRCUIT_REF])
+        assert len(captured) == 0
+
+
+def test_compile_circuit_with_wrapper() -> None:
+    """
+    Test that `start_compile_job` is correctly invoked when the deprecated
+    `circuits` keyword argument is supplied. The `accept_circuits_for_programs`
+    decorator implements this.
+    """
+    with mock.patch("qnexus.client.jobs._compile.get_nexus_client") as gnc:
+        mock_client = mock.MagicMock()
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 202
+        mock_resp.json.return_value = {
+            "data": {
+                "id": str(uuid4()),
+                "attributes": {
+                    "name": "blah",
+                    "timestamps": {
+                        "created": dt.datetime.now(),
+                        "modified": dt.datetime.now(),
+                    },
+                },
+            }
+        }
+
+        mock_client.post.return_value = mock_resp
+        gnc.return_value = mock_client
+
+        gnc.post.return_value = mock_resp
+
+        with warnings.catch_warnings(record=True) as captured:
+            start_compile_job(
+                name="foo",
+                backend_config=QuantinuumConfig(device_name="whatever"),
+                circuits=[CIRCUIT_REF],
+                project=PROJECT_REF,
+            )
+            assert captured[0].category == DeprecationWarning
+
+        assert mock_client.post.call_count == 1
+        assert (
+            "program_id"
+            in mock_client.post.call_args[1]["json"]["data"]["attributes"][
+                "definition"
+            ]["items"][0]
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,6 @@ from unittest import mock
 from uuid import uuid4
 import warnings
 
-import pytest
-
 from qnexus.client.utils import accept_circuits_for_programs
 from qnexus.models.references import CircuitRef, ProjectRef
 from qnexus.client.jobs._compile import start_compile_job
@@ -42,7 +40,7 @@ def test_wrapper() -> None:
     with warnings.catch_warnings(record=True) as captured:
         inner_fn("hello", circuits=[CIRCUIT_REF])  # type: ignore
         assert len(captured) == 1
-        assert captured[0].category == DeprecationWarning
+        assert captured[0].category is DeprecationWarning
 
     with warnings.catch_warnings(record=True) as captured:
         inner_fn("hello", programs=[CIRCUIT_REF])
@@ -85,7 +83,7 @@ def test_compile_circuit_with_wrapper() -> None:
                 circuits=[CIRCUIT_REF],  # type: ignore
                 project=PROJECT_REF,
             )
-            assert captured[0].category == DeprecationWarning
+            assert captured[0].category is DeprecationWarning
 
         assert mock_client.post.call_count == 1
         assert (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ def test_wrapper() -> None:
         assert len(captured) == 0
 
     with warnings.catch_warnings(record=True) as captured:
-        inner_fn("hello", circuits=[CIRCUIT_REF])
+        inner_fn("hello", circuits=[CIRCUIT_REF])  # type: ignore
         assert len(captured) == 1
         assert captured[0].category == DeprecationWarning
 
@@ -82,7 +82,7 @@ def test_compile_circuit_with_wrapper() -> None:
             start_compile_job(
                 name="foo",
                 backend_config=QuantinuumConfig(device_name="whatever"),
-                circuits=[CIRCUIT_REF],
+                circuits=[CIRCUIT_REF],  # type: ignore
                 project=PROJECT_REF,
             )
             assert captured[0].category == DeprecationWarning


### PR DESCRIPTION
BREAKING CHANGE: this changes name of the argument to `start_execute_job` from `circuits` to `programs` (same for `start_circuit_job` and the convenience methods `compile` and `execute`)