### PR TITLE
test: add additional tests to test basic functionality of supported BackendConfigs

### DIFF
--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -3,12 +3,13 @@
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Generator
+from typing import Generator, cast
 
 import pytest
 from hugr.package import Package
 from pytket.circuit import Circuit
 from pytket.wasm.wasm import WasmFileHandler
+from quantinuum_schemas.models.backend_config import BackendConfig
 
 import qnexus as qnx
 from qnexus.config import CONFIG
@@ -184,3 +185,35 @@ def qa_wasm_module_name_fixture() -> str:
 def qa_hugr_name_fixture() -> str:
     """A name for uniquely identifying a HUGR owned by the Nexus QA user."""
     return f"qnexus_integration_test_hugr_{datetime.now()}"
+
+
+@pytest.fixture(
+    scope="session",
+    params=[
+        # Nexus-hosted
+        qnx.AerConfig(),
+        qnx.AerStateConfig(),
+        qnx.AerUnitaryConfig(),
+        qnx.BraketConfig(local=True),
+        qnx.QuantinuumConfig(device_name="H1-1LE"),
+        qnx.ProjectQConfig(),
+        qnx.QulacsConfig(),
+        # Non Nexus-hosted
+        qnx.IBMQConfig(
+            backend_name="ibm_sherbrooke",
+            hub="ibm-q",
+            group="open",
+            project="main",
+        ),
+        qnx.IBMQEmulatorConfig(
+            backend_name="ibm_sherbrooke",
+            hub="ibm-q",
+            group="open",
+            project="main",
+        ),
+        qnx.QuantinuumConfig(device_name="H1-1SC"),  # Cluster-hosted
+    ],
+)
+def backend_config(request: pytest.FixtureRequest) -> BackendConfig:
+    """Fixture to provide an instance of all BackendConfigs for testing."""
+    return cast(BackendConfig, request.param)

--- a/integration/test_backend_configs.py
+++ b/integration/test_backend_configs.py
@@ -1,0 +1,67 @@
+"""Tests that we can use all available backend configs."""
+
+from datetime import datetime
+
+from pytket.backends.backendresult import BackendResult
+from pytket.circuit import Circuit
+
+import qnexus as qnx
+
+CONFIGS_REQUIRE_NO_MEASURE = [qnx.AerUnitaryConfig]
+CONFIGS_NOT_TO_EXECUTE = [
+    # We won't execute for these configs as they run on quantum hardware
+    qnx.IBMQConfig
+]
+
+
+def test_basic_backend_config_usage(
+    _authenticated_nexus: None,
+    backend_config: qnx.BackendConfig,
+    qa_project_name: str,
+) -> None:
+    """Test basic functionality of supported BackendConfigs."""
+
+    project_ref = qnx.projects.get(name_like=qa_project_name)
+
+    my_circ = Circuit(2, 2).H(0).CX(0, 1)
+
+    if backend_config.__class__ in CONFIGS_REQUIRE_NO_MEASURE:
+        my_circ.measure_all()
+
+    my_circ = qnx.circuits.upload(
+        circuit=my_circ,
+        name=f"QA BackendConfig circuit {backend_config.__class__.__name__}_{datetime.now()}",
+        description=f"This can be safely deleted. Test Run: {datetime.now()}",
+        project=project_ref,
+    )
+
+    compile_job_ref = qnx.start_compile_job(
+        programs=[my_circ],
+        name=f"QA BackendConfig compile job {backend_config.__class__.__name__}_{datetime.now()}",
+        optimisation_level=0,
+        backend_config=backend_config,
+        project=project_ref,
+    )
+
+    qnx.jobs.wait_for(compile_job_ref)
+
+    # Check the backend config as stored in Nexus matches the one specified
+    assert qnx.jobs.get(id=compile_job_ref.id).backend_config == backend_config
+
+    if backend_config.__class__ in CONFIGS_NOT_TO_EXECUTE:
+        return
+
+    execute_job_ref = qnx.start_execute_job(
+        programs=[item.get_output() for item in qnx.jobs.results(compile_job_ref)],
+        name=f"Execute {backend_config.__class__.__name__}_{datetime.now()}",
+        n_shots=[100],
+        backend_config=backend_config,
+        project=project_ref,
+    )
+
+    qnx.jobs.wait_for(execute_job_ref)
+
+    execute_job_result_refs = qnx.jobs.results(execute_job_ref)
+
+    for result_ref in execute_job_result_refs:
+        assert isinstance(result_ref.download_result(), BackendResult)

--- a/integration/test_devices.py
+++ b/integration/test_devices.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pytket.backends.backendinfo import BackendInfo
+from quantinuum_schemas.models.backend_config import BackendConfig
 from quantinuum_schemas.models.backend_info import StoredBackendInfo
 
 import qnexus as qnx
@@ -24,102 +25,85 @@ def test_device_get_all(
 
 def test_supports_shots(
     _authenticated_nexus: None,
+    backend_config: BackendConfig,
 ) -> None:
     """Test whether a BackendConfig supports shots."""
-    backend_config = qnx.QuantinuumConfig(device_name="H1-1LE")
 
     supports_shots = qnx.devices.supports_shots(backend_config)
-
     assert isinstance(supports_shots, bool)
-    assert supports_shots is True
 
 
 def test_supports_counts(
     _authenticated_nexus: None,
+    backend_config: BackendConfig,
 ) -> None:
     """Test whether a BackendConfig supports counts."""
-    backend_config = qnx.QuantinuumConfig(device_name="H1-1LE")
 
     supports_counts = qnx.devices.supports_counts(backend_config)
-
     assert isinstance(supports_counts, bool)
-    assert supports_counts is True
 
 
 def test_supports_state(
     _authenticated_nexus: None,
+    backend_config: BackendConfig,
 ) -> None:
     """Test whether a BackendConfig supports state."""
-    backend_config = qnx.QuantinuumConfig(device_name="H1-1LE")
 
     supports_state = qnx.devices.supports_state(backend_config)
-
     assert isinstance(supports_state, bool)
-    assert supports_state is False
 
 
 def test_supports_unitary(
     _authenticated_nexus: None,
+    backend_config: BackendConfig,
 ) -> None:
     """Test whether a BackendConfig supports unitary."""
-    backend_config = qnx.QuantinuumConfig(device_name="H1-1LE")
 
     supports_unitary = qnx.devices.supports_unitary(backend_config)
-
     assert isinstance(supports_unitary, bool)
-    assert supports_unitary is False
 
 
 def test_supports_density_matrix(
     _authenticated_nexus: None,
+    backend_config: BackendConfig,
 ) -> None:
     """Test whether a BackendConfig supports density matrix."""
-    backend_config = qnx.QuantinuumConfig(device_name="H1-1LE")
 
     supports_density_matrix = qnx.devices.supports_density_matrix(backend_config)
-
     assert isinstance(supports_density_matrix, bool)
-    assert supports_density_matrix is False
 
 
 def test_supports_expectation(
     _authenticated_nexus: None,
+    backend_config: BackendConfig,
 ) -> None:
     """Test whether a BackendConfig supports expectation."""
-    backend_config = qnx.QuantinuumConfig(device_name="H1-1LE")
 
     supports_expectation = qnx.devices.supports_expectation(backend_config)
-
     assert isinstance(supports_expectation, bool)
-    assert supports_expectation is False
 
 
 def test_expectation_allows_nonhermitian(
     _authenticated_nexus: None,
+    backend_config: BackendConfig,
 ) -> None:
     """Test whether a BackendConfig supports expectation_allows_nonhermitian."""
-    backend_config = qnx.QuantinuumConfig(device_name="H1-1LE")
 
     expectation_allows_nonhermitian = qnx.devices.expectation_allows_nonhermitian(
         backend_config
     )
-
     assert isinstance(expectation_allows_nonhermitian, bool)
-    assert expectation_allows_nonhermitian is False
 
 
 def test_supports_contextual_optimisation(
     _authenticated_nexus: None,
+    backend_config: BackendConfig,
 ) -> None:
     """Test whether a BackendConfig supports contextual optimisation."""
-    backend_config = qnx.QuantinuumConfig(device_name="H1-1LE")
-
     supports_contextual_optimisation = qnx.devices.supports_contextual_optimisation(
         backend_config
     )
-
     assert isinstance(supports_contextual_optimisation, bool)
-    assert supports_contextual_optimisation is True
 
 
 def test_quantinuum_device_status(


### PR DESCRIPTION
Runs some basic tests that we can:
- compile and execute for each BackendConfig
- get properties of each BackendConfig