### PR TITLE
chore: add backend config name to test id

### DIFF
--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -187,6 +187,15 @@ def qa_hugr_name_fixture() -> str:
     return f"qnexus_integration_test_hugr_{datetime.now()}"
 
 
+def get_backend_config_name(backend_config: qnx.BackendConfig) -> str:
+    name = backend_config.__class__.__name__
+    if hasattr(backend_config, "backend_name"):
+        name += f"({backend_config.backend_name})"
+    if hasattr(backend_config, "device_name"):
+        name += f"({backend_config.device_name})"
+    return name
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -213,7 +222,7 @@ def qa_hugr_name_fixture() -> str:
         ),
         qnx.QuantinuumConfig(device_name="H1-1SC"),  # Cluster-hosted
     ],
-    ids=lambda config: config.__class__.__name__,
+    ids=get_backend_config_name,
 )
 def backend_config(request: pytest.FixtureRequest) -> BackendConfig:
     """Fixture to provide an instance of all BackendConfigs for testing."""


### PR DESCRIPTION
Simple change so the name of the config tested in the `test_backend_configs.py` is part of the test's name. I.e., `test_basic_backend_config_usage[AerConfig]` instead of `test_basic_backend_config_usage[backend_config0]`.