### PR TITLE
fix: Update wasm_examples.ipynb to add measures to circuit

### DIFF
--- a/examples/basics/wasm_examples.ipynb
+++ b/examples/basics/wasm_examples.ipynb
@@ -80,7 +80,7 @@
     "circuit = Circuit(1)\n",
     "# Very minimal WASM example\n",
     "a = circuit.add_c_register(\"a\", 8)\n",
-    "circuit.add_wasm_to_reg(\"add_one\", wfh, [a], [a])\n"
+    "circuit.add_wasm_to_reg(\"add_one\", wfh, [a], [a])\n",
     "circuit.measure_all()"
    ]
   },


### PR DESCRIPTION
The current example is giving the error:
```
Job errored with detail: <class 'hqscompiler.comperror.CompError'>: Compile error:  Program does not have any measurements
```
Adding `circuit.measure_all` fixes this issue.