### PR TITLE
chore: add SeleneConfig exports

### DIFF
--- a/qnexus/__init__.py
+++ b/qnexus/__init__.py
@@ -3,7 +3,25 @@
 import warnings
 
 import nest_asyncio  # type: ignore
+from quantinuum_schemas.models.backend_config import (
+    AerConfig,
+    AerStateConfig,
+    AerUnitaryConfig,
+    BackendConfig,
+    BraketConfig,
+    IBMQConfig,
+    IBMQEmulatorConfig,
+    ProjectQConfig,
+    QuantinuumConfig,
+    QulacsConfig,
+    SeleneClassicalReplayConfig,
+    SeleneCoinflipConfig,
+    SeleneLeanConfig,
+    SeleneQuestConfig,
+    SeleneStimConfig,
+)
 
+import qnexus.models as models
 from qnexus import context, filesystem
 from qnexus.client import (
     auth,
@@ -23,18 +41,6 @@ from qnexus.client.auth import login, login_with_credentials, logout
 from qnexus.client.jobs import compile, execute
 from qnexus.client.jobs._compile import start_compile_job
 from qnexus.client.jobs._execute import start_execute_job
-from qnexus.models import (
-    AerConfig,
-    AerStateConfig,
-    AerUnitaryConfig,
-    BackendConfig,
-    BraketConfig,
-    IBMQConfig,
-    IBMQEmulatorConfig,
-    ProjectQConfig,
-    QuantinuumConfig,
-    QulacsConfig,
-)
 
 warnings.filterwarnings("default", category=DeprecationWarning, module=__name__)
 
@@ -77,4 +83,10 @@ __all__ = [
     "ProjectQConfig",
     "QuantinuumConfig",
     "QulacsConfig",
+    "SeleneCoinflipConfig",
+    "SeleneClassicalReplayConfig",
+    "SeleneLeanConfig",
+    "SeleneStimConfig",
+    "SeleneQuestConfig",
+    "models",
 ]

--- a/qnexus/client/jobs/_execute.py
+++ b/qnexus/client/jobs/_execute.py
@@ -77,7 +77,7 @@ def start_execute_job(
             "job_type": "execute",
             "definition": {
                 "job_definition_type": "execute_job_definition",
-                "backend_config": backend_config.model_dump(),
+                "backend_config": backend_config.model_dump(exclude_none=True),
                 "user_group": user_group,
                 "valid_check": valid_check,
                 "postprocess": postprocess,

--- a/qnexus/models/__init__.py
+++ b/qnexus/models/__init__.py
@@ -24,8 +24,19 @@ from quantinuum_schemas.models.backend_config import (
     ProjectQConfig,
     QuantinuumConfig,
     QulacsConfig,
+    SeleneClassicalReplayConfig,
+    SeleneCoinflipConfig,
+    SeleneLeanConfig,
+    SeleneQuestConfig,
+    SeleneStimConfig,
 )
 from quantinuum_schemas.models.backend_info import Register, StoredBackendInfo
+from quantinuum_schemas.models.selene_config import (
+    DepolarizingErrorModel,
+    HeliosRuntime,
+    NoErrorModel,
+    SimpleRuntime,
+)
 
 from qnexus.models.annotations import Annotations
 from qnexus.models.references import TeamRef, UserRef
@@ -45,6 +56,15 @@ __all__ = [
     "QuantinuumConfig",
     "QulacsConfig",
     "StoredBackendInfo",
+    "SeleneCoinflipConfig",
+    "SeleneClassicalReplayConfig",
+    "SeleneLeanConfig",
+    "SeleneStimConfig",
+    "SeleneQuestConfig",
+    "HeliosRuntime",
+    "SimpleRuntime",
+    "NoErrorModel",
+    "DepolarizingErrorModel",
 ]
 
 


### PR DESCRIPTION
This will allow for sightly easier imports of Selene configuration models:

```
import qnexus as qnx

config = qnx.SeleneQuestConfig(
    n_qubits=1,
    seed=123,
    noise_model=qnx.models.NoErrorModel(),
    runtime=qnx.models.HeliosRuntime(),
)
```

I would kinda like to remove the exports of BackendConfigs from `qnx.QuantinuumConfig()` to `qnx.models.QuantinuumConfig()` but I figure this would break a lot of scripts. Any thoughts? 
