### PR TITLE
chore: Use httpx to create ssl context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "pydantic-settings >=2, <3.0",
     "quantinuum-schemas>=4.0.0,<5.0",
     "hugr >=0.11.5, <1.0.0",
-    "certifi>=2025.1.31",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2533,7 +2533,6 @@ name = "qnexus"
 version = "0.25.0"
 source = { editable = "." }
 dependencies = [
-    { name = "certifi" },
     { name = "click" },
     { name = "colorama" },
     { name = "httpx" },
@@ -2577,7 +2576,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "certifi", specifier = ">=2025.1.31" },
     { name = "click", specifier = ">=8.1,<9.0" },
     { name = "colorama", specifier = ">=0.4,<1.0" },
     { name = "httpx", specifier = ">=0,<1" },


### PR DESCRIPTION
httpx actually has a very similar function to create an ssl context that we can just use directly instead of trying to manage it ourselves. This will mean that our websockets implementation will also have the same ssl behaviour as httpx.