### PR TITLE
fix: getting incomplete results for error'd jobs

### DIFF
--- a/qnexus/client/jobs/_execute.py
+++ b/qnexus/client/jobs/_execute.py
@@ -161,11 +161,13 @@ def _results(
         ):
             result_type: ResultType
 
-            match item["result_type"]:
+            match item.get("result_type", None):
                 case ResultType.QSYS:
                     result_type = ResultType.QSYS
                 case ResultType.PYTKET:
                     result_type = ResultType.PYTKET
+                case None:
+                    continue
                 case _:
                     assert_never(item["result_type"])
 


### PR DESCRIPTION
`test_get_results_for_incomplete_execute` has been broken since the partial results changes have been merged, but because the tests were in a bad state it has been missed.

This is the least disruptive way I could see to stop if failing. It is required because some jobs error before they have any results. and in that case they don't have any result type or other result info stored about them.