### PR TITLE
fix: get pytket results shots

### DIFF
--- a/qnexus/client/jobs/_execute.py
+++ b/qnexus/client/jobs/_execute.py
@@ -195,7 +195,8 @@ def _fetch_pytket_execution_result(
 
     res_dict = res.json()
     next_key = res_dict["data"]["attributes"].get("next_key")
-    shots = res_dict["data"]["attributes"].get(["shots"])
+    shots = res_dict["data"]["attributes"].get("shots")
+
     while next_key is not None:
         next_partial_res = get_nexus_client().get(
             f"/api/results/v1beta3/partial/{result_ref.id}?{next_key}"


### PR DESCRIPTION
In #230 we introduced a bug while trying to access the pytket result shots with `.get(["shots"])` instead of `.get("shots")`. This was causing multiple failures in the integration tests with `TypeError: unhashable type: 'list'` (see [this](https://github.com/CQCL/qnexus/actions/runs/16749537365/job/47416027206) run for example).