### PR TITLE
feat: qnexus emits warnings if the Nexus server indicates that its version is not current

### DIFF
--- a/qnexus/client/__init__.py
+++ b/qnexus/client/__init__.py
@@ -2,6 +2,7 @@
 
 import typing
 import warnings
+from importlib.metadata import version
 from urllib.parse import urlparse
 
 import httpx
@@ -9,6 +10,20 @@ import httpx
 from qnexus.client.utils import read_token, write_token
 from qnexus.config import CONFIG
 from qnexus.exceptions import AuthenticationError
+
+# Used by the client to identify its own version when refreshing auth token
+# Example value: 0.23.0
+VERSION_HEADER = "X-qnexus-version"
+
+# Used by the server to specify the latest version
+# Example value: 1.0.0
+LATEST_VERSION_HEADER = "X-qnexus-version-latest"
+
+# Used by the server to indicate the status of a version
+# Example value: 0.23.0; deprecated
+VERSION_STATUS_HEADER = "X-qnexus-version-status"
+
+VERSION = version("qnexus")
 
 
 class AuthHandler(httpx.Auth):
@@ -70,6 +85,8 @@ class AuthHandler(httpx.Auth):
             if request.headers.get("cookie"):
                 request.headers.pop("cookie")
             self.cookies.set_cookie_header(request)
+
+            _check_version_headers(auth_response)
             yield request
 
     def build_refresh_request(self) -> httpx.Request:
@@ -79,6 +96,7 @@ class AuthHandler(httpx.Auth):
             method="POST",
             url=f"{CONFIG.url}/auth/tokens/refresh",
             cookies=self.cookies,
+            headers={VERSION_HEADER: VERSION},
         )
 
 
@@ -115,3 +133,18 @@ def _check_sunset_header(request: httpx.Request, response: httpx.Response) -> No
             "After this date your current qnexus version may stop functioning. Please update to a later qnexus version to resolve the issue.",
             category=DeprecationWarning,
         )
+
+
+def _check_version_headers(response: httpx.Response) -> None:
+    latest_version = response.headers.get(LATEST_VERSION_HEADER)
+    version_status = response.headers.get(VERSION_STATUS_HEADER)
+    if latest_version != VERSION and version_status:
+        try:
+            _version, status = [s.strip() for s in version_status.split(";")]
+        except ValueError:
+            return
+        if status != "current":
+            warnings.warn(
+                f"Your qnexus client version is {VERSION}, which is {status}. Version {latest_version} is available. Please consider upgrading.",
+                category=DeprecationWarning,
+            )

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,10 +1,18 @@
+import typing
 import warnings
+from importlib.metadata import version
 
 import httpx
 import respx
 
 import qnexus as qnx
-from qnexus.client import get_nexus_client
+from qnexus.client import (
+    LATEST_VERSION_HEADER,
+    VERSION_HEADER,
+    VERSION_STATUS_HEADER,
+    get_nexus_client,
+)
+from qnexus.client.utils import write_token
 
 
 @respx.mock
@@ -28,3 +36,53 @@ def test_sunset_header_emits_warning() -> None:
     message = str(captured[0].message)
     assert fake_date in message
     assert "(" + path + ")" in message
+
+
+@respx.mock
+def test_qnexus_version_check_emits_warning() -> None:
+    """
+    GIVEN: a server that includes a http header with a new version of qnexus
+           and an indication that upgrade is advised
+    WHEN:  the auth token is refreshed from an old version of qnexus
+    THEN:  a warning is emitted, prompting the user to upgrade
+    """
+    write_token("refresh_token", "dummy_oat")
+
+    # Mock the list projects endpoint to force a refresh
+    respx.get(f"{get_nexus_client().base_url}/api/projects/v1beta").mock(
+        side_effect=[
+            httpx.Response(401),
+            httpx.Response(200, json={"included": {}, "data": []}),
+        ]
+    )
+
+    # Mock the refresh endpoint
+    latest_version = "999.99.999-never-gonna-happen"
+    version_status = "really bad"
+    refresh_token_route = respx.post(
+        f"{get_nexus_client().base_url}/auth/tokens/refresh"
+    ).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            headers={
+                LATEST_VERSION_HEADER: latest_version,
+                VERSION_STATUS_HEADER: "x;" + version_status,
+            },
+        )
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        qnx.projects.get_all().list()
+
+    assert refresh_token_route.call_count == 1
+    call: respx.models.Call = refresh_token_route.calls[0]
+    headers: typing.MutableMapping[str, str] = call.request.headers
+    assert headers[VERSION_HEADER] == version("qnexus")
+
+    assert len(captured) == 1
+    assert captured[0].category is DeprecationWarning
+    message = str(captured[0].message)
+    assert version("qnexus") in message
+    assert latest_version in message
+    assert version_status in message
+    assert "Please consider upgrading" in message


### PR DESCRIPTION
With this PR, `qnexus` will include a header when it refreshes its auth token, for example:

```
POST /auth/tokens/refresh
...(other headers)...
X-qnexus-version: 0.12.3
...
```

To begin with, Nexus will ignore this header. But - _if and when we implement this server-side_ - it can begin to respond with two new headers:

```
X-qnexus-version-latest: 0.34.5
X-qnexus-version-status: 0.12.3;deprecated
```

With this PR, the above response headers would cause this warning to be emitted, visible to the end user.

```
Your qnexus client version is 0.12.3, which is deprecated.
Version 0.34.5 is available. Please consider upgrading.
```

We should get this into the client ASAP, because existing qnexus versions have no such mechanism: their users will have to find out some other way that they are out of date.

Then we can implement the server side logic as and when we have time.  A simple implementation could be to check pypi APIs and cache the latest version for (say) 15m.  This is [easy to do](https://stackoverflow.com/a/34366589):

```python3
import requests  # we would rewrite to use httpx, maybe
import json
from packaging.version import parse


URL_PATTERN = "https://pypi.python.org/pypi/{package}/json"


def get_version(package, url_pattern=URL_PATTERN):
    """Return version of package on pypi.python.org using json."""
    req = requests.get(url_pattern.format(package=package))
    version = parse("0")
    if req.status_code == requests.codes.ok:
        j = json.loads(req.text.encode(req.encoding or "utf8"))
        releases = j.get("releases", [])
        for release in releases:
            ver = parse(release)
            if not ver.is_prerelease:
                version = max(version, ver)
    return version


if __name__ == "__main__":
    print("The latest version of qnexus is %s" % get_version("qnexus"))
```