### PR TITLE
chore: check version during login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,9 @@ jobs:
 
       - name: Test with pytest
         run: |
-          uv run pytest tests/test_auth.py::test_token_refresh --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
-          uv run pytest tests/test_auth.py::test_nexus_client_reloads_tokens --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
-          uv run pytest tests/test_auth.py::test_nexus_client_reloads_domain --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
-          uv run pytest tests/test_auth.py::test_token_refresh_expired --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
-
-          uv run pytest tests/ -v --ignore=tests/test_auth.py --doctest-modules --cov=qnexus --cov-report=html --cov-report=term
+          uv run scripts/run_unit_tests.sh
+          uv run coverage report
+          uv run coverage html
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@master

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = --strict-markers -n 2 --reruns 3
+addopts = --strict-markers -n 2 --reruns 3 --cov=qnexus --cov-report= --cov-append --doctest-modules
 markers =
     create: marks tests as those that have side effects involving resource creation (deselect with '-m "not create"')

--- a/qnexus/client/__init__.py
+++ b/qnexus/client/__init__.py
@@ -145,6 +145,6 @@ def _check_version_headers(response: httpx.Response) -> None:
             return
         if status.lower() not in ("current", "ok"):
             warnings.warn(
-                f"Your qnexus client version is {VERSION}, which is {status}. Version {latest_version} is available. Please consider upgrading.",
+                f"Your qnexus client version is {VERSION}, which is {status}.\nVersion {latest_version} is available. Please consider upgrading.",
                 category=DeprecationWarning,
             )

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -12,7 +12,12 @@ from rich.console import Console
 from rich.panel import Panel
 
 import qnexus.exceptions as qnx_exc
-from qnexus.client import get_nexus_client
+from qnexus.client import (
+    VERSION,
+    VERSION_HEADER,
+    _check_version_headers,
+    get_nexus_client,
+)
 from qnexus.client.utils import consolidate_error, remove_token, write_token
 from qnexus.config import CONFIG
 
@@ -79,7 +84,10 @@ def login() -> None:
         polling_for_seconds += poll_interval
         resp = _get_auth_client().post(
             "/device/token",
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                VERSION_HEADER: VERSION,
+            },
             data=token_request_body,
         )
         if (
@@ -101,6 +109,7 @@ def login() -> None:
             print(
                 f"✅ Successfully logged in as {resp_json['email']} using the browser."
             )
+            _check_version_headers(resp)
             return
         # Fail for all other statuses
         consolidate_error(res=resp, description="Browser Login")

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -153,6 +153,7 @@ def _request_tokens(user: EmailStr, pwd: str) -> None:
         resp = _get_auth_client().post(
             "/login",
             json=body,
+            headers={VERSION_HEADER: VERSION},
         )
 
         mfa_redirect_uri = resp.json().get("redirect_uri", "")
@@ -187,6 +188,8 @@ def _request_tokens(user: EmailStr, pwd: str) -> None:
         write_token("refresh_token", myqos_oat)
         write_token("access_token", myqos_id)
         get_nexus_client(reload=True)
+
+        _check_version_headers(resp)
 
     finally:
         del user

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -4,7 +4,7 @@ set -e
 
 # Order doesn't matter but auth tests manipulate environment variables
 # and should be run separately
-uv run pytest tests/test_auth.py::test_token_refresh
+uv run pytest --cov-reset tests/test_auth.py::test_token_refresh
 uv run pytest tests/test_auth.py::test_nexus_client_reloads_tokens
 uv run pytest tests/test_auth.py::test_nexus_client_reloads_domain
 uv run pytest tests/test_auth.py::test_token_refresh_expired

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -47,16 +47,18 @@ def _check_version_warning_emitted(warning_msgs: list[warnings.WarningMessage]) 
     Assert that a warning has been emitted with all the properties we'd expect
     when we notify a user that they need to upgrade their client.
     """
-    matched = False
     for warning_msg in warning_msgs:
-        assert warning_msg.category is DeprecationWarning
-        message = str(warning_msg.message)
-        assert version("qnexus") in message
-        assert FAKE_LATEST_VERSION in message
-        assert FAKE_VERSION_STATUS in message
-        assert "Please consider upgrading" in message
-        matched = True
-    assert matched, (
+        try:
+            assert warning_msg.category is DeprecationWarning
+            message = str(warning_msg.message)
+            assert version("qnexus") in message
+            assert FAKE_LATEST_VERSION in message
+            assert FAKE_VERSION_STATUS in message
+            assert "Please consider upgrading" in message
+            return
+        except AssertionError:
+            pass  # on to the next warning, if any
+    assert False, (
         f"The expected warning was not found (checked {len(warning_msgs)} warning messages)."
     )
 

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,6 +1,7 @@
 import typing
 import warnings
 from importlib.metadata import version
+from unittest import mock
 
 import httpx
 import respx
@@ -13,6 +14,9 @@ from qnexus.client import (
     get_nexus_client,
 )
 from qnexus.client.utils import write_token
+
+FAKE_LATEST_VERSION = "999.99.999-never-gonna-happen"
+FAKE_VERSION_STATUS = "really bad"
 
 
 @respx.mock
@@ -38,8 +42,38 @@ def test_sunset_header_emits_warning() -> None:
     assert "(" + path + ")" in message
 
 
+def _check_version_warning_emitted(warning_msgs: list[warnings.WarningMessage]) -> None:
+    """
+    Assert that a warning has been emitted with all the properties we'd expect
+    when we notify a user that they need to upgrade their client.
+    """
+    matched = False
+    for warning_msg in warning_msgs:
+        assert warning_msg.category is DeprecationWarning
+        message = str(warning_msg.message)
+        assert version("qnexus") in message
+        assert FAKE_LATEST_VERSION in message
+        assert FAKE_VERSION_STATUS in message
+        assert "Please consider upgrading" in message
+        matched = True
+    assert matched, (
+        f"The expected warning was not found (checked {len(warning_msgs)} warning messages)."
+    )
+
+
+def _check_request_includes_version_data(r: respx.Route) -> None:
+    """
+    Verify that a single call to a server URL has been made, and that it
+    includes the expected version identifier header.
+    """
+    assert r.call_count == 1
+    call: respx.models.Call = r.calls[0]
+    headers: typing.MutableMapping[str, str] = call.request.headers
+    assert headers[VERSION_HEADER] == version("qnexus")
+
+
 @respx.mock
-def test_qnexus_version_check_emits_warning() -> None:
+def test_version_check_emits_warning_refresh_token() -> None:
     """
     GIVEN: a server that includes a http header with a new version of qnexus
            and an indication that upgrade is advised
@@ -48,7 +82,7 @@ def test_qnexus_version_check_emits_warning() -> None:
     """
     write_token("refresh_token", "dummy_oat")
 
-    # Mock the list projects endpoint to force a refresh
+    # Mock the list projects endpoint to force a token refresh
     respx.get(f"{get_nexus_client().base_url}/api/projects/v1beta").mock(
         side_effect=[
             httpx.Response(401),
@@ -56,17 +90,15 @@ def test_qnexus_version_check_emits_warning() -> None:
         ]
     )
 
-    # Mock the refresh endpoint
-    latest_version = "999.99.999-never-gonna-happen"
-    version_status = "really bad"
+    # Mock the token refresh endpoint
     refresh_token_route = respx.post(
         f"{get_nexus_client().base_url}/auth/tokens/refresh"
     ).mock(
         return_value=httpx.Response(
             status_code=200,
             headers={
-                LATEST_VERSION_HEADER: latest_version,
-                VERSION_STATUS_HEADER: "x;" + version_status,
+                LATEST_VERSION_HEADER: FAKE_LATEST_VERSION,
+                VERSION_STATUS_HEADER: "x;" + FAKE_VERSION_STATUS,
             },
         )
     )
@@ -74,15 +106,51 @@ def test_qnexus_version_check_emits_warning() -> None:
     with warnings.catch_warnings(record=True) as captured:
         qnx.projects.get_all().list()
 
-    assert refresh_token_route.call_count == 1
-    call: respx.models.Call = refresh_token_route.calls[0]
-    headers: typing.MutableMapping[str, str] = call.request.headers
-    assert headers[VERSION_HEADER] == version("qnexus")
+    _check_request_includes_version_data(refresh_token_route)
+    _check_version_warning_emitted(captured)
 
-    assert len(captured) == 1
-    assert captured[0].category is DeprecationWarning
-    message = str(captured[0].message)
-    assert version("qnexus") in message
-    assert latest_version in message
-    assert version_status in message
-    assert "Please consider upgrading" in message
+
+@mock.patch("qnexus.client.auth.webbrowser")
+@respx.mock
+def test_version_check_emits_warning_login(m: mock.Mock) -> None:
+    """
+    GIVEN: a server that includes a http header with a new version of qnexus
+           and an indication that upgrade is advised
+    WHEN:  the login method is called from an old version of qnexus
+    THEN:  a warning is emitted, prompting the user to upgrade
+    """
+    base_url = get_nexus_client().base_url
+
+    # Mock the login endpoints
+    respx.post(f"{base_url}/auth/device/device_authorization").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "user_code": "",
+                "device_code": "",
+                "verification_uri_complete": "https://example.com",
+                "expires_in": 5,
+                "interval": 1,
+            },
+        )
+    )
+    token_request_route = respx.post(f"{base_url}/auth/device/token").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "refresh_token": "foo",
+                "access_token": "bar",
+                "email": "foo@example.com",
+            },
+            headers={
+                LATEST_VERSION_HEADER: FAKE_LATEST_VERSION,
+                VERSION_STATUS_HEADER: "x;" + FAKE_VERSION_STATUS,
+            },
+        )
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        qnx.login()
+
+    _check_request_includes_version_data(token_request_route)
+    _check_version_warning_emitted(captured)


### PR DESCRIPTION
(in addition to during token refresh, which was added in https://github.com/CQCL/qnexus/pull/245)

This is for users who use `qnexus` outside of Nexus's jupyterlab environment.  At the first point when they interact with the Nexus servers, the client will report its version and can now show a warning if the server reports that it's out of date.

I added a test for this too, which means that `qnx.login()` is now covered by >=1 unit test as well as integration tests.

I also fixed the coverage reporting and unified the CI with the script