### PR TITLE
feat: use default HUGR compression

### DIFF
--- a/integration/test_hugr.py
+++ b/integration/test_hugr.py
@@ -2,9 +2,11 @@
 
 from typing import Callable, ContextManager
 
+import pytest
 from hugr.package import Package
 
 import qnexus as qnx
+import qnexus.exceptions as qnx_exc
 from qnexus.models.annotations import PropertiesDict
 from qnexus.models.references import HUGRRef, ProjectRef, Ref
 
@@ -54,8 +56,12 @@ def test_hugr_download(
         hugr_name,
         qa_hugr_package,
     ) as hugr_ref:
-        downloaded_hugr_package = hugr_ref.download_hugr()
-        assert isinstance(downloaded_hugr_package, Package)
+        with pytest.raises(qnx_exc.ResourceFetchFailed):
+            # Temporarily disabled due to missing functionality in hugr
+            downloaded_hugr_package = hugr_ref.download_hugr()
+            assert isinstance(downloaded_hugr_package, Package)
+        downloaded_hugr_bytes = hugr_ref.download_hugr_bytes()
+        assert isinstance(downloaded_hugr_bytes, bytes)
 
 
 def test_hugr_get_by_id(

--- a/qnexus/models/references.py
+++ b/qnexus/models/references.py
@@ -264,6 +264,7 @@ class HUGRRef(BaseRef):
     project: ProjectRef
     id: UUID
     _contents: Package | None = None
+    _bytes: bytes | None = None
     type: Literal["HUGRRef"] = "HUGRRef"
 
     def download_hugr(self) -> Package:
@@ -276,6 +277,17 @@ class HUGRRef(BaseRef):
 
         self._contents = _fetch_hugr_package(self)
         return self._contents
+
+    def download_hugr_bytes(self) -> bytes:
+        """Get the HUGR bytes of the original uploaded HUGR."""
+
+        if self._bytes:
+            return self._bytes
+
+        from qnexus.client.hugr import _fetch_hugr_bytes
+
+        self._bytes = _fetch_hugr_bytes(self)
+        return self._bytes
 
     def df(self) -> pd.DataFrame:
         """Present in a pandas DataFrame."""


### PR DESCRIPTION
- [ ] use the default HUGR compression (should be much better)
- [ ] disable reserializing HUGR into Package from bytes (the new compression format doesn't support this yet)