### PR TITLE
test: Don't assert on changing field

### DIFF
--- a/integration/test_jobs.py
+++ b/integration/test_jobs.py
@@ -96,6 +96,7 @@ def test_job_get_by_id(
             exclude={
                 "last_message": True,
                 "last_status": True,
+                "system": True,
                 "__all__": {"contents_modified": True, "modified": True},
             }
         )


### PR DESCRIPTION
The tests that check the status of the Compile job ref are prone to flaking because it's comparing a reference from the point of compilation to a reference that comes a little later. In this time if the compilation is started it will have a system saved which will then be included in the response.