### PR TITLE
feat: add region support for login and configuration management

### DIFF
--- a/examples/basics/auth_quotas.ipynb
+++ b/examples/basics/auth_quotas.ipynb
@@ -33,6 +33,11 @@
     "```\n",
     "\n",
     "```python\n",
+    "# Login with the browser and specify a region\n",
+    "qnx.login(region=\"us\")\n",
+    "```\n",
+    "\n",
+    "```python\n",
     "# Login by passing your credentials\n",
     "qnx.login_with_credentials()\n",
     "```"

--- a/qnexus/cli/auth.py
+++ b/qnexus/cli/auth.py
@@ -1,14 +1,16 @@
 """CLI for qnexus."""
 
+from typing import Any
+
 import click
 
 from ..client import auth as _auth
 
 
 @click.command()
-def login() -> None:
+def login(**kwargs: Any) -> None:
     """Log in to quantinuum nexus using your web browser."""
-    click.echo(_auth.login())  # type: ignore[func-returns-value]
+    click.echo(_auth.login(**kwargs))  # type: ignore[func-returns-value]
 
 
 @click.command()

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -23,6 +23,7 @@ from qnexus.client import (
 )
 from qnexus.client.utils import consolidate_error, read_token, remove_token, write_token
 from qnexus.config import CONFIG
+from qnexus.models.region import Region, get_hostname
 
 console = Console()
 
@@ -76,13 +77,20 @@ def _get_auth_client() -> httpx.Client:
     )
 
 
-def login(force: bool = False) -> None:
+def login(force: bool = False, region: Region | None = None) -> None:
     """
     Log in to Quantinuum Nexus using the web browser.
 
     (if web browser can't be launched, displays the link)
     """
-    if not force and is_logged_in():
+    different_domain = False
+    if region is not None:
+        domain = get_hostname(region)
+        if domain != CONFIG.domain:
+            different_domain = True
+            CONFIG.domain = domain
+
+    if not force and not different_domain and is_logged_in():
         print("Already logged in. Tokens are valid.")
         return
 
@@ -165,9 +173,16 @@ def login(force: bool = False) -> None:
     raise qnx_exc.AuthenticationError("Browser login Failed, code has expired.")
 
 
-def login_with_credentials(force: bool = False) -> None:
+def login_with_credentials(force: bool = False, region: Region | None = None) -> None:
     """Log in to Nexus using a username and password."""
-    if not force and is_logged_in():
+    different_domain = False
+    if region is not None:
+        domain = get_hostname(region)
+        if domain != CONFIG.domain:
+            different_domain = True
+            CONFIG.domain = domain
+
+    if not force and not different_domain and is_logged_in():
         print("Already logged in. Tokens are valid.")
         return
     user_name = input("Enter your Nexus email: ")
@@ -178,11 +193,20 @@ def login_with_credentials(force: bool = False) -> None:
     print(f"✅ Successfully logged in as {user_name}.")
 
 
-def login_no_interaction(user: EmailStr, pwd: str, force: bool = False) -> None:
+def login_no_interaction(
+    user: EmailStr, pwd: str, force: bool = False, region: Region | None = None
+) -> None:
     """Log in to Nexus using a username and password.
     Please be careful with storing credentials in plain text or source code.
     """
-    if not force and is_logged_in():
+    different_domain = False
+    if region is not None:
+        domain = get_hostname(region)
+        if domain != CONFIG.domain:
+            different_domain = True
+            CONFIG.domain = domain
+
+    if not force and not different_domain and is_logged_in():
         print("Already logged in. Tokens are valid.")
         return
     _request_tokens(user=user, pwd=pwd)

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -77,18 +77,26 @@ def _get_auth_client() -> httpx.Client:
     )
 
 
+def _update_domain_for_region(region: Region | None) -> bool:
+    """Update configured domain for a region and report whether it changed."""
+    if region is None:
+        return False
+
+    domain = get_hostname(region)
+    if domain != CONFIG.domain:
+        CONFIG.domain = domain
+        return True
+
+    return False
+
+
 def login(force: bool = False, region: Region | None = None) -> None:
     """
     Log in to Quantinuum Nexus using the web browser.
 
     (if web browser can't be launched, displays the link)
     """
-    different_domain = False
-    if region is not None:
-        domain = get_hostname(region)
-        if domain != CONFIG.domain:
-            different_domain = True
-            CONFIG.domain = domain
+    different_domain = _update_domain_for_region(region)
 
     if not force and not different_domain and is_logged_in():
         print("Already logged in. Tokens are valid.")
@@ -175,12 +183,7 @@ def login(force: bool = False, region: Region | None = None) -> None:
 
 def login_with_credentials(force: bool = False, region: Region | None = None) -> None:
     """Log in to Nexus using a username and password."""
-    different_domain = False
-    if region is not None:
-        domain = get_hostname(region)
-        if domain != CONFIG.domain:
-            different_domain = True
-            CONFIG.domain = domain
+    different_domain = _update_domain_for_region(region)
 
     if not force and not different_domain and is_logged_in():
         print("Already logged in. Tokens are valid.")
@@ -199,12 +202,7 @@ def login_no_interaction(
     """Log in to Nexus using a username and password.
     Please be careful with storing credentials in plain text or source code.
     """
-    different_domain = False
-    if region is not None:
-        domain = get_hostname(region)
-        if domain != CONFIG.domain:
-            different_domain = True
-            CONFIG.domain = domain
+    different_domain = _update_domain_for_region(region)
 
     if not force and not different_domain and is_logged_in():
         print("Already logged in. Tokens are valid.")

--- a/qnexus/config.py
+++ b/qnexus/config.py
@@ -1,7 +1,18 @@
 """Quantinuum Nexus API client configuration via pydantic-settings."""
 
+import os
+
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def _resolve_env_file() -> str:
+    """Resolve the settings env file path.
+
+    Supports an explicit override via ``NEXUS_CONFIG_FILE`` and defaults to
+    ``~/.qnexus/config``.
+    """
+    return os.path.expanduser(os.getenv("NEXUS_CONFIG_FILE", "~/.qnexus/config"))
 
 
 class Config(BaseSettings):
@@ -9,7 +20,10 @@ class Config(BaseSettings):
 
     Uses pydantic-settings to read environment variables for qnexus configuration."""
 
-    model_config = SettingsConfigDict(env_prefix="NEXUS_")
+    model_config = SettingsConfigDict(
+        env_prefix="NEXUS_",
+        env_file=_resolve_env_file(),
+    )
 
     # web
     protocol: str = "https"

--- a/qnexus/models/region.py
+++ b/qnexus/models/region.py
@@ -1,0 +1,21 @@
+"""Region model for QNexus API client."""
+
+import os
+from typing import Literal
+
+Region = Literal["us", "sg"]
+
+
+def get_hostname(region: Region) -> str:
+    """Get the hostname for a given region."""
+
+    # Use environment variable override if set, otherwise fall back to defaults
+    hostname_override = os.getenv(f"NEXUS_{region.upper()}_DOMAIN")
+    if hostname_override:
+        return hostname_override
+
+    if region == "us":
+        return "nexus.quantinuum.com"
+    if region == "sg":
+        return "nexus.quantinuum.sg"
+    raise ValueError(f"Invalid region: {region}")

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -8,6 +8,7 @@ uv run pytest --cov-reset tests/test_auth.py::test_token_refresh
 uv run pytest tests/test_auth.py::test_nexus_client_reloads_tokens
 uv run pytest tests/test_auth.py::test_nexus_client_reloads_domain
 uv run pytest tests/test_auth.py::test_token_refresh_expired
+uv run pytest tests/test_auth.py::test_login_region_sg_uses_sg_domain_and_does_not_short_circuit
 
 
 echo "Running non-auth tests"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,6 +4,7 @@ N.B. these manipulate environment variables so currently run in isolation via sc
 """
 
 from typing import Any, Generator
+from unittest import mock
 from uuid import uuid4
 
 import httpx
@@ -117,6 +118,56 @@ def test_token_refresh_expired() -> None:
 
     assert list_project_route.called
     assert refresh_token_route.called
+
+
+@respx.mock
+def test_login_region_sg_uses_sg_domain_and_does_not_short_circuit() -> None:
+    """`login(region="sg")` should target SG auth endpoints and bypass already-logged-in short-circuit."""
+    original_domain = CONFIG.domain
+
+    try:
+        sg_domain = "nexus.quantinuum.sg"
+
+        device_auth_route = respx.post(
+            f"https://{sg_domain}:443/auth/device/device_authorization"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                json={
+                    "user_code": "ABC-123",
+                    "device_code": "device-code",
+                    "verification_uri_complete": "https://example.com/verify",
+                    "expires_in": 2,
+                    "interval": 1,
+                },
+            )
+        )
+        token_route = respx.post(f"https://{sg_domain}:443/auth/device/token").mock(
+            return_value=httpx.Response(
+                status_code=200,
+                json={
+                    "refresh_token": "dummy_oat",
+                    "access_token": "dummy_id",
+                    "email": "user@example.com",
+                },
+            )
+        )
+
+        with (
+            mock.patch(
+                "qnexus.client.auth.is_logged_in", return_value=True
+            ) as is_logged_in,
+            mock.patch("qnexus.client.auth.webbrowser.open", return_value=True),
+            mock.patch("qnexus.client.auth.time.sleep", return_value=None),
+        ):
+            qnx.login(region="sg")
+
+        assert CONFIG.domain == sg_domain
+        assert device_auth_route.called
+        assert token_route.called
+        assert is_logged_in.call_count == 0
+    finally:
+        CONFIG.domain = original_domain
 
 
 def test_nexus_client_reloads_tokens() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,51 @@
+"""Tests for qnexus config loading behavior."""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from qnexus.config import Config, _resolve_env_file
+
+
+def test_config_can_be_loaded_from_explicit_env_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`Config` should read values from an explicit env file path."""
+    monkeypatch.delenv("NEXUS_DOMAIN", raising=False)
+    monkeypatch.delenv("NEXUS_HOST", raising=False)
+    config_file = tmp_path / "qnexus.env"
+    config_file.write_text("NEXUS_DOMAIN=example.test\nNEXUS_PORT=8443\n")
+
+    config = Config(_env_file=str(config_file), _env_file_encoding="utf-8")
+
+    assert config.domain == "example.test"
+    assert config.port == 8443
+
+
+def test_resolve_env_file_uses_nexus_config_file_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`NEXUS_CONFIG_FILE` should override the default env file path."""
+    monkeypatch.setenv("NEXUS_CONFIG_FILE", "~/.qnexus/custom")
+    assert _resolve_env_file() == str(Path.home() / ".qnexus" / "custom")
+
+
+def test_module_config_uses_resolved_env_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Module-level `CONFIG` should load values from `NEXUS_CONFIG_FILE`."""
+    config_file = tmp_path / "qnexus.config"
+    config_file.write_text("NEXUS_DOMAIN=from-file.test\n")
+
+    import qnexus.config as config_module
+
+    try:
+        monkeypatch.delenv("NEXUS_DOMAIN", raising=False)
+        monkeypatch.delenv("NEXUS_HOST", raising=False)
+        monkeypatch.setenv("NEXUS_CONFIG_FILE", str(config_file))
+        config_module = importlib.reload(config_module)
+        assert config_module.CONFIG.domain == "from-file.test"
+    finally:
+        monkeypatch.delenv("NEXUS_CONFIG_FILE", raising=False)
+        importlib.reload(config_module)

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,0 +1,22 @@
+"""Tests for region hostname resolution."""
+
+import pytest
+
+from qnexus.models.region import get_hostname
+
+
+def test_get_hostname_defaults() -> None:
+    """Falls back to built-in hostnames when no overrides are set."""
+    assert get_hostname("us") == "nexus.quantinuum.com"
+    assert get_hostname("sg") == "nexus.quantinuum.sg"
+
+
+def test_get_hostname_uses_region_environment_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use NEXUS_<REGION>_DOMAIN when provided for a region."""
+    monkeypatch.setenv("NEXUS_US_DOMAIN", "custom.us.example.com")
+    monkeypatch.setenv("NEXUS_SG_DOMAIN", "custom.sg.example.com")
+
+    assert get_hostname("us") == "custom.us.example.com"
+    assert get_hostname("sg") == "custom.sg.example.com"


### PR DESCRIPTION
Introduce support for region-specific login and configuration management, allowing users to specify a region during authentication. 

qnx.login now supports an optional region param like `us` or `sg` to update the domain to connect to.

Note: To override the production domains, users can set NEXUS_US_DOMAIN and NEXUS_SG_DOMAIN variables.