### PR TITLE
feat: enable in-memory tokens

### DIFF
--- a/qnexus/__init__.py
+++ b/qnexus/__init__.py
@@ -36,7 +36,7 @@ from qnexus.client import (
     users,
     wasm_modules,
 )
-from qnexus.client.auth import login, login_with_credentials, logout
+from qnexus.client.auth import login, login_with_credentials, login_with_token, logout
 from qnexus.client.jobs import compile, execute
 from qnexus.client.jobs._compile import start_compile_job
 from qnexus.client.jobs._execute import start_execute_job
@@ -74,6 +74,7 @@ __all__ = [
     "start_execute_job",
     "login",
     "login_with_credentials",
+    "login_with_token",
     "logout",
     "AerConfig",
     "AerStateConfig",

--- a/qnexus/client/__init__.py
+++ b/qnexus/client/__init__.py
@@ -48,6 +48,30 @@ class AuthHandler(httpx.Auth):
         except FileNotFoundError:
             pass
 
+    def set_tokens(self, refresh_token: str) -> None:
+        """Inject a refresh token and obtain an access token in-memory.
+
+        The refresh token is set on the handler's cookies and immediately
+        exchanged for a fresh access token via the server.  No tokens are
+        written to disk regardless of ``CONFIG.store_tokens``.
+
+        Raises:
+            AuthenticationError: If the refresh token is invalid or expired.
+        """
+        self.cookies.clear()
+        self.cookies.set("myqos_oat", refresh_token, domain=CONFIG.domain)
+
+        response = httpx.post(
+            f"{CONFIG.url}/auth/tokens/refresh",
+            cookies=self.cookies,
+            headers={VERSION_HEADER: VERSION},
+            verify=CONFIG.httpx_verify,
+        )
+        if response.status_code == 401:
+            raise AuthenticationError("Refresh token is invalid or expired.")
+        response.raise_for_status()
+        self.cookies.extract_cookies(response)
+
     def auth_flow(
         self, request: httpx.Request
     ) -> typing.Generator[httpx.Request, httpx.Response, None]:

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -235,6 +235,19 @@ def logout() -> None:
     print("Successfully logged out.")
 
 
+def login_with_token(refresh_token: str) -> None:
+    """Authenticate using a refresh token held in memory.
+
+    Sets the token on the current client's auth handler and exchanges
+    it for a fresh access token.  No tokens are written to disk.
+
+    This is intended for programmatic use where the caller manages
+    token storage externally (e.g. multiple accounts).
+    """
+    client = get_nexus_client(reload=True)
+    client.auth.set_tokens(refresh_token)  # type: ignore[union-attr]
+
+
 def _request_tokens(user: EmailStr, pwd: str) -> None:
     """Method to send login request to Nexus auth api and save tokens."""
     body = {"email": user, "password": pwd}

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -243,7 +243,21 @@ def login_with_token(refresh_token: str) -> None:
 
     This is intended for programmatic use where the caller manages
     token storage externally (e.g. multiple accounts).
+
+    >>> import qnexus as qnx
+    >>> from qnexus.config import CONFIG
+    >>> CONFIG.store_tokens = False
+    >>>  alice_token = "foo"
+    >>>  bob_token = "bar"
+
+    >>> qnx.login_with_token(alice_token)
+    >>> qnx.projects.get_all()  # runs as alice
+
+    >>> qnx.login_with_token(bob_token)
+    >>> qnx.projects.get_all()  # runs as bob
+
     """
+
     client = get_nexus_client(reload=True)
     client.auth.set_tokens(refresh_token)  # type: ignore[union-attr]
 

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -244,17 +244,37 @@ def login_with_token(refresh_token: str) -> None:
     This is intended for programmatic use where the caller manages
     token storage externally (e.g. multiple accounts).
 
-    >>> import qnexus as qnx
-    >>> from qnexus.config import CONFIG
-    >>> CONFIG.store_tokens = False
-    >>>  alice_token = "foo"
-    >>>  bob_token = "bar"
+    **Multi-process usage:** Each Python process has its own client
+    instance, so separate processes can each call ``login_with_token``
+    with different user tokens without interfering with each other.
+    Set ``CONFIG.store_tokens = False`` to prevent other code paths
+    (e.g. automatic token refresh) from writing to the shared
+    ``~/.qnx/auth/`` directory.
 
-    >>> qnx.login_with_token(alice_token)
-    >>> qnx.projects.get_all()  # runs as alice
+    **Single-process token hot-swapping:** You can switch between
+    users sequentially within a single process. All subsequent API
+    calls will use the most recently set token::
 
-    >>> qnx.login_with_token(bob_token)
-    >>> qnx.projects.get_all()  # runs as bob
+        import qnexus as qnx
+        from qnexus.config import CONFIG
+        CONFIG.store_tokens = False
+
+        alice_token = "..."
+        bob_token = "..."
+
+        qnx.login_with_token(alice_token)
+        qnx.projects.get_all()  # runs as alice
+
+        qnx.login_with_token(bob_token)
+        qnx.projects.get_all()  # runs as bob
+
+    .. warning::
+        This function is **not thread-safe**. The client and its auth
+        cookies are shared process-wide without locking. If one thread
+        calls ``login_with_token(alice_token)`` while another thread is
+        mid-request as Bob, the cookies can be in an inconsistent state.
+        For concurrent multi-user workloads, use separate processes
+        rather than threads within a single process.
 
     """
 

--- a/qnexus/client/utils.py
+++ b/qnexus/client/utils.py
@@ -42,7 +42,11 @@ def normalize_included(included: list[Any]) -> dict[str, dict[str, Any]]:
 
 def remove_token(token_type: TokenTypes) -> None:
     """Delete a token file."""
+    if not CONFIG.store_tokens:
+        return
 
+    # Don't try to delete refresh token in Jupyterhub
+    # these get mounted in automatically and managed externally
     if is_managed_token_environment() and token_type == "refresh_token":
         return
     token_file_path = Path.home() / CONFIG.token_path / token_file_from_type[token_type]
@@ -89,7 +93,11 @@ def read_token(token_type: TokenTypes) -> str:
 
 def write_token(token_type: TokenTypes, token: str) -> None:
     """Write a token to a file."""
+    if not CONFIG.store_tokens:
+        return
 
+    # Don't allow writing of refresh token in Jupyterhub
+    # these get mounted in automatically and managed externally
     if is_managed_token_environment() and token_type == "refresh_token":
         return
 

--- a/qnexus/client/utils.py
+++ b/qnexus/client/utils.py
@@ -45,8 +45,6 @@ def remove_token(token_type: TokenTypes) -> None:
     if not CONFIG.store_tokens:
         return
 
-    # Don't try to delete refresh token in Jupyterhub
-    # these get mounted in automatically and managed externally
     if is_managed_token_environment() and token_type == "refresh_token":
         return
     token_file_path = Path.home() / CONFIG.token_path / token_file_from_type[token_type]
@@ -96,8 +94,6 @@ def write_token(token_type: TokenTypes, token: str) -> None:
     if not CONFIG.store_tokens:
         return
 
-    # Don't allow writing of refresh token in Jupyterhub
-    # these get mounted in automatically and managed externally
     if is_managed_token_environment() and token_type == "refresh_token":
         return
 

--- a/qnexus/config.py
+++ b/qnexus/config.py
@@ -36,7 +36,7 @@ class Config(BaseSettings):
     httpx_verify: bool = True
 
     # auth
-    store_tokens: bool = True  # Not implemented
+    store_tokens: bool = True
     token_path: str = ".qnx/auth"
 
     # testing

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -9,6 +9,8 @@ uv run pytest tests/test_auth.py::test_nexus_client_reloads_tokens
 uv run pytest tests/test_auth.py::test_nexus_client_reloads_domain
 uv run pytest tests/test_auth.py::test_token_refresh_expired
 uv run pytest tests/test_auth.py::test_login_region_sg_uses_sg_domain_and_does_not_short_circuit
+uv run pytest tests/test_auth.py::test_login_with_token_sets_cookies_in_memory
+uv run pytest tests/test_auth.py::test_login_with_token_swap_between_accounts
 
 
 echo "Running non-auth tests"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -222,3 +222,75 @@ def test_nexus_client_reloads_domain() -> None:
     assert domain_two not in str(client_one.base_url)
     # client_two getter should reload the client
     assert domain_two in str(client_two.base_url)
+
+
+@respx.mock
+def test_login_with_token_sets_cookies_in_memory() -> None:
+    """Test that login_with_token injects the refresh token and exchanges it
+    for an access token, all held in memory on the client's auth handler."""
+
+    alice_refresh = "alice_refresh"
+    alice_access = "alice_access"
+
+    # Mock the refresh endpoint to return an access token cookie
+    refresh_route = respx.post(f"{CONFIG.url}/auth/tokens/refresh").mock(
+        return_value=httpx.Response(
+            200,
+            headers={
+                "set-cookie": f"myqos_id={alice_access}; "
+                "HttpOnly; Path=/; SameSite=Lax; Secure"
+            },
+        )
+    )
+
+    qnx.login_with_token(alice_refresh)
+
+    client = get_nexus_client()
+    assert refresh_route.called
+    assert client.auth.cookies.get("myqos_oat") == alice_refresh  # type: ignore
+    assert client.auth.cookies.get("myqos_id") == alice_access  # type: ignore
+
+
+@respx.mock
+def test_login_with_token_swap_between_accounts() -> None:
+    """Test hot-swapping between two accounts using login_with_token.
+
+    After each swap the client should hold only the most recent account's tokens."""
+
+    alice_refresh = "alice_refresh"
+    alice_access = "alice_access"
+    bob_refresh = "bob_refresh"
+    bob_access = "bob_access"
+
+    refresh_route = respx.post(f"{CONFIG.url}/auth/tokens/refresh").mock(
+        side_effect=[
+            httpx.Response(
+                200,
+                headers={
+                    "set-cookie": f"myqos_id={alice_access}; "
+                    "HttpOnly; Path=/; SameSite=Lax; Secure"
+                },
+            ),
+            httpx.Response(
+                200,
+                headers={
+                    "set-cookie": f"myqos_id={bob_access}; "
+                    "HttpOnly; Path=/; SameSite=Lax; Secure"
+                },
+            ),
+        ]
+    )
+
+    # Swap to alice
+    qnx.login_with_token(alice_refresh)
+    client = get_nexus_client()
+    assert client.auth.cookies.get("myqos_oat") == alice_refresh  # type: ignore
+    assert client.auth.cookies.get("myqos_id") == alice_access  # type: ignore
+
+    # Swap to bob
+    qnx.login_with_token(bob_refresh)
+    client = get_nexus_client()
+    assert client.auth.cookies.get("myqos_oat") == bob_refresh  # type: ignore
+    assert client.auth.cookies.get("myqos_id") == bob_access  # type: ignore
+
+    assert refresh_route.call_count == 2


### PR DESCRIPTION
Enables keeping auth tokens purely in memory, and passing a refresh token to perform a manual login.