### PR TITLE
fix: add timeout parameter to circuits.cost

### DIFF
--- a/qnexus/client/circuits.py
+++ b/qnexus/client/circuits.py
@@ -314,7 +314,7 @@ def cost(
     backend_config: BackendConfig,
     syntax_checker: str | None = None,
     project: ProjectRef | None = None,
-    timeout: float| None=None,
+    timeout: float| int | None=None,
 ) -> float | None:
     """Estimate the cost (in HQC) of running Circuit programs for n_shots
     number of shots on a Quantinuum H2 system.

--- a/qnexus/client/circuits.py
+++ b/qnexus/client/circuits.py
@@ -314,7 +314,7 @@ def cost(
     backend_config: BackendConfig,
     syntax_checker: str | None = None,
     project: ProjectRef | None = None,
-    timeout: float| int | None = None,
+    timeout: float | int | None = None,
 ) -> float | None:
     """Estimate the cost (in HQC) of running Circuit programs for n_shots
     number of shots on a Quantinuum H2 system.
@@ -372,6 +372,6 @@ def cost(
         project=project,
         name="Circuit cost estimation job",
     )
-    status = qnx.jobs.wait_for(job_ref,timeout=timeout)
+    status = qnx.jobs.wait_for(job_ref, timeout=timeout)
 
     return cast(float, status.cost)

--- a/qnexus/client/circuits.py
+++ b/qnexus/client/circuits.py
@@ -314,6 +314,7 @@ def cost(
     backend_config: BackendConfig,
     syntax_checker: str | None = None,
     project: ProjectRef | None = None,
+    timeout: float| None=None,
 ) -> float | None:
     """Estimate the cost (in HQC) of running Circuit programs for n_shots
     number of shots on a Quantinuum H2 system.
@@ -371,6 +372,6 @@ def cost(
         project=project,
         name="Circuit cost estimation job",
     )
-    status = qnx.jobs.wait_for(job_ref)
+    status = qnx.jobs.wait_for(job_ref,timeout=timeout)
 
     return cast(float, status.cost)

--- a/qnexus/client/circuits.py
+++ b/qnexus/client/circuits.py
@@ -314,7 +314,7 @@ def cost(
     backend_config: BackendConfig,
     syntax_checker: str | None = None,
     project: ProjectRef | None = None,
-    timeout: float| int | None=None,
+    timeout: float| int | None = None,
 ) -> float | None:
     """Estimate the cost (in HQC) of running Circuit programs for n_shots
     number of shots on a Quantinuum H2 system.

--- a/qnexus/client/hugr.py
+++ b/qnexus/client/hugr.py
@@ -278,6 +278,7 @@ def cost(
     n_shots: int | list[int],
     project: ProjectRef | None = None,
     system_name: Literal["Helios-1"] = "Helios-1",
+    timeout: float | int | None = None
 ) -> float:
     """Estimate the cost (in HQC) of running Hugr programs for n_shots
     number of shots on a Quantinuum Helios system.
@@ -303,7 +304,7 @@ def cost(
         project=project,
         name="Hugr cost estimation job",
     )
-    status = qnx.jobs.wait_for(job_ref)
+    status = qnx.jobs.wait_for(job_ref, timeout=timeout)
 
     return cast(float, status.cost)
 

--- a/qnexus/client/qir.py
+++ b/qnexus/client/qir.py
@@ -257,6 +257,7 @@ def cost(
     n_shots: int | list[int],
     project: ProjectRef | None = None,
     system_name: Literal["Helios-1"] = "Helios-1",
+    timeout: float | int | None = None
 ) -> float:
     """Estimate the cost (in HQC) of running QIR programs for n_shots
     number of shots on a Quantinuum Helios system.
@@ -282,7 +283,7 @@ def cost(
         project=project,
         name="QIR cost estimation job",
     )
-    status = qnx.jobs.wait_for(job_ref)
+    status = qnx.jobs.wait_for(job_ref, timeout=timeout)
 
     return cast(float, status.cost)
 


### PR DESCRIPTION
qnx.jobs.wait_for has a timeout parameter that is set to 900 as a default. 
There was not way for the user to override this parameter when calling circuits.cost. Thus, as soon as the circuit execution on the syntax checker took longer than 900s, circuits.cost raises an exception. Therefore, this commit adds an optional timeout parameter to circuits.cost. If the user specifies nothing, qnx.jobs.wait_for will use its own default timeout value of 900. Thus, this minor change will not break any previously written code.