### PR TITLE
chore: fix tests for when tokens are not stored on disk

### DIFF
--- a/integration/test_auth_flows.py
+++ b/integration/test_auth_flows.py
@@ -24,9 +24,11 @@ def test_credential_login_full_flow(
     pwd = CONFIG.qa_user_password
 
     qnx.logout()
-    with pytest.raises(FileNotFoundError):
-        read_token(token_type="access_token")
-        read_token(token_type="refresh_token")
+
+    if CONFIG.store_tokens:
+        with pytest.raises(FileNotFoundError):
+            read_token(token_type="access_token")
+            read_token(token_type="refresh_token")
 
     with pytest.raises(AuthenticationError):
         qnx.users.get_self()
@@ -37,24 +39,25 @@ def test_credential_login_full_flow(
 
     qnx.login_with_credentials()
 
-    assert read_token(token_type="access_token") != ""
-    assert read_token(token_type="refresh_token") != ""
+    if CONFIG.store_tokens:
+        assert read_token(token_type="access_token") != ""
+        assert read_token(token_type="refresh_token") != ""
 
+    # Verify authentication works regardless of token storage mode
     qnx.users.get_self()
 
     qnx.logout()
-    with pytest.raises(FileNotFoundError):
-        read_token(token_type="access_token")
-        read_token(token_type="refresh_token")
+
+    if CONFIG.store_tokens:
+        with pytest.raises(FileNotFoundError):
+            read_token(token_type="access_token")
+            read_token(token_type="refresh_token")
 
     with pytest.raises(AuthenticationError):
         qnx.users.get_self()
 
     # Login again to make sure credentials are in the system for the other tests
-    # fake user input from stdin
-    monkeypatch.setattr("sys.stdin", StringIO(username + "\n"))
-    monkeypatch.setattr("getpass.getpass", lambda prompt: pwd)
-    qnx.login_with_credentials()
+    login_no_interaction(username, pwd, force=True)
 
 
 @pytest.mark.skip(reason="Not implemented")

--- a/qnexus/client/auth.py
+++ b/qnexus/client/auth.py
@@ -40,23 +40,26 @@ def is_logged_in() -> bool:
         if not refresh_token or not access_token:
             return False
     except FileNotFoundError:
-        return False
-    # Check expiry of refresh token (assume JWT)
-    try:
-        payload = jwt.decode(refresh_token, options={"verify_signature": False})
-        exp = payload.get("exp")
-        if exp:
-            expiry_dt = datetime.datetime.fromtimestamp(exp)
-            now = datetime.datetime.now()
-            hours_left = (expiry_dt - now).total_seconds() / 3600
-            if hours_left < 24:
-                msg = (
-                    f"Your refresh token expires in less than 24 hours (expires at {expiry_dt}). "
-                    "You will need to login again after this time or use force=True to refresh now."
-                )
-                warnings.warn(msg, category=UserWarning)
-    except jwt.PyJWTError:
+        # If tokens aren't on disk, fall through to the network check
+        # in case we have valid in-memory tokens (e.g. store_tokens=False).
         pass
+    else:
+        # Check expiry of refresh token (assume JWT)
+        try:
+            payload = jwt.decode(refresh_token, options={"verify_signature": False})
+            exp = payload.get("exp")
+            if exp:
+                expiry_dt = datetime.datetime.fromtimestamp(exp)
+                now = datetime.datetime.now()
+                hours_left = (expiry_dt - now).total_seconds() / 3600
+                if hours_left < 24:
+                    msg = (
+                        f"Your refresh token expires in less than 24 hours (expires at {expiry_dt}). "
+                        "You will need to login again after this time or use force=True to refresh now."
+                    )
+                    warnings.warn(msg, category=UserWarning)
+        except jwt.PyJWTError:
+            pass
     # Try a lightweight authenticated request to check validity
     try:
         client = get_nexus_client()
@@ -323,7 +326,11 @@ def _request_tokens(user: EmailStr, pwd: str) -> None:
 
         write_token("refresh_token", myqos_oat)
         write_token("access_token", myqos_id)
-        get_nexus_client(reload=True)
+        client = get_nexus_client(reload=True)
+        # Set tokens directly in memory so auth works even when
+        # store_tokens=False (where write_token is a no-op).
+        client.auth.cookies.set("myqos_oat", myqos_oat, domain=CONFIG.domain)  # type: ignore[union-attr]
+        client.auth.cookies.set("myqos_id", myqos_id, domain=CONFIG.domain)  # type: ignore[union-attr]
 
         _check_version_headers(resp)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -21,6 +21,10 @@ from qnexus.exceptions import AuthenticationError
 @pytest.fixture(autouse=True)
 def clean_token_state() -> Generator[Any, Any, Any]:
     """Clean up token state before and after each test."""
+    # Ensure tokens are stored to disk for these tests
+    old_store_tokens = CONFIG.store_tokens
+    CONFIG.store_tokens = True
+
     # Setup - clean token files
     remove_token("refresh_token")
     remove_token("access_token")
@@ -40,6 +44,7 @@ def clean_token_state() -> Generator[Any, Any, Any]:
     remove_token("access_token")
     get_nexus_client(reload=True)
     CONFIG.token_path = old_token_path
+    CONFIG.store_tokens = old_store_tokens
 
 
 @respx.mock

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -4,9 +4,11 @@ import time
 import typing
 import warnings
 from importlib.metadata import version
+from typing import Any, Generator
 from unittest import mock
 
 import httpx
+import pytest
 import respx
 
 import qnexus as qnx
@@ -18,6 +20,17 @@ from qnexus.client import (
 )
 from qnexus.client.auth import is_logged_in
 from qnexus.client.utils import write_token
+from qnexus.config import CONFIG
+
+
+@pytest.fixture(autouse=True)
+def ensure_store_tokens() -> Generator[Any, Any, Any]:
+    """Ensure store_tokens is True for tests that write tokens to disk."""
+    old_store_tokens = CONFIG.store_tokens
+    CONFIG.store_tokens = True
+    yield
+    CONFIG.store_tokens = old_store_tokens
+
 
 FAKE_LATEST_VERSION = "999.99.999-never-gonna-happen"
 FAKE_VERSION_STATUS = "really bad"


### PR DESCRIPTION
This enables in-memory tokens during CI integration testing, should fix the broken tests